### PR TITLE
Improve function io type checking

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -45,13 +45,16 @@ A client is a healthcare system object that requests information and processing 
 
 A client is typically an EHR system, but we may also support other health objects in the future such as a CPOE (Computerized Ohysician Order Entry).
 
-We can mark a client by using the decorator `@hc.ehr`. You **must** declare a **workflow** for EHR clients, which informs the sandbox how your data will be formatted (See [Use Cases](usecases.md)).
+We can mark a client by using the decorator `@hc.ehr`. You must declare a particular **workflow** for the EHR client, which informs the sandbox how your data will be formatted (See [Use Cases](usecases.md)).
+
+Data returned from the client should be wrapped in a [Pydantic](https://docs.pydantic.dev/latest/) model depending on use case, e.g. `CdsFhirData`.
 
 You can optionally specify if you want more than 1 request generated with the `num` parameter.
 
 ```python
 import healthchain as hc
 from healthchain.use_cases import ClinicalDecisionSupport
+from healthchain.models import CdsFhirData
 
 @hc.sandbox
 class MyCoolSandbox(ClinicalDecisionSupport):
@@ -59,7 +62,7 @@ class MyCoolSandbox(ClinicalDecisionSupport):
         pass
 
     @hc.ehr(workflow="patient-view", num=10)
-    def load_data_in_client(self):
+    def load_data_in_client(self) -> CdsFhirData:
         # Do things here to load in your data
         pass
 
@@ -69,9 +72,9 @@ class MyCoolSandbox(ClinicalDecisionSupport):
 ### Data Generator
 Healthcare data is interoperable, but not composable - every deployment site will have different ways of configuring data and terminology. This matters when you develop applications that need to integrate into these systems, especially when you need to reliably extract data for your model to consume.
 
-The aim of the Data Generator is not to generate realistic data suitable for use cases such as patient population studies, but rather to generate data that is structurally compliant with what is expected of EHR configurations, and to be able to test and handle variations in this.
+The aim of the data generator is not to generate realistic data suitable for use cases such as patient population studies, but rather to generate data that is structurally compliant with what is expected of EHR configurations, and to be able to test and handle variations in this.
 
-For this reason the data generator is opiniated by use case and workflow. See [Use Cases](usecases.md).
+For this reason the data generator is opiniated by use case and workflow. See [Use Cases](usecases.md) for more information.
 
 !!! note
     We're aware we may not cover everyone's use cases, so if you have strong opinions about this, please [reach out](https://discord.gg/jG4UWCUh)!
@@ -80,43 +83,54 @@ On the synthetic data spectrum defined by [this UK ONS methodology working paper
 
 ![Synthetic data](assets/synthetic_data_ons.png)
 
-You can use the data generator within a Client function or on its own. The `.data` attribute contains a Pydantic class containing `context` and `resources`.
+You can use the data generator within a client function or on its own. The `.generate()` is dependent on workflow. For CDS use cases, it will return a `CdsFhirData` model with the `prefetch` field populated with a [Bundle](https://www.hl7.org/fhir/bundle.html) of generated structural synthetic FHIR data.
 
 === "Within client"
     ```python
     import healthchain as hc
-    from healthchain.data_generator import DataGenerator
     from healthchain.use_cases import ClinicalDecisionSupport
+    from healthchain.models import CdsFhirData
+    from healthchain.data_generator import CdsDataGenerator
 
     @hc.sandbox
     class MyCoolSandbox(ClinicalDecisionSupport):
         def __init__(self) -> None:
-            self.data_generator = DataGenerator()
+            self.data_generator = CdsDataGenerator()
 
         @hc.ehr(workflow="patient-view")
-        def load_data_in_client(self):
-            self.data_generator.generate()
-            return self.data_generator.data
+        def load_data_in_client(self) -> CdsFhirData:
+            data = self.data_generator.generate()
+            return data
 
         @hc.api
-        def my_server(self, text):
+        def my_server(self, request) -> None:
             pass
     ```
 
 
 === "On its own"
     ```python
-    from healthchain.data_generator import DataGenerator
+    from healthchain.data_generator import CdsDataGenerator
     from healthchain.base import Workflow
 
     # Initialise data generator
-    data_generator = DataGenerator()
+    data_generator = CdsDataGenerator()
 
     # Generate FHIR resources for use case workflow
     data_generator.set_workflow(Workflow.encounter_discharge)
-    data_generator.generate()
+    data = data_generator.generate()
 
-    print(data_generator.data.resources.model_dump(by_alias=True, exclude_unset=True))
+    print(data.model_dump())
+
+    # {
+    #    "prefetch": {
+    #        "entry": [
+    #            {
+    #                "resource": ...
+    #            }
+    #        ]
+    #    }
+    #}
     ```
 
 <!-- You can pass in parameters in `contraint` argument to limit the general form of the FHIR resources you get back, but this feature is experimental. Arguments supported are:
@@ -147,9 +161,11 @@ data_generator.generate(free_text_csv="./dir/to/csv/file")
 
 
 ### Service API
-A service is typically an API of an external AI/NLP system that returns data to the client. This is where you define your application logic - it can be anything from a simple regex to a highly sophisticated LLM agentic workflow. The only constraint is that you have to return your data as a `Dict` that your workflow expects.
+A service is typically an API of an external AI/NLP system that returns data to the client. This is where you define your application logic - it can be anything from a simple regex to a highly sophisticated LLM agentic workflow.
 
 When you decorate a function with `@hc.api` in a sandbox, the function is mounted to a HL7-compliant service endpoint an EHR client can make requests to. This is usually a set of standardised API routes depending on the use case. HealthChain will start a [FastAPI](https://fastapi.tiangolo.com/) server with these APIs pre-defined for you.
+
+Your service function must accept and return models appropriate for your use case. Typically the service function should accept a `Request` model and return a use case specific model, such as a list of `Card` for CDS.
 
 If you are using a model that requires initialisation steps, we recommend you initialise this in your class `__init__`.
 
@@ -161,35 +177,34 @@ If you are using a model that requires initialisation steps, we recommend you in
     import healthchain as hc
 
     from healthchain.use_cases import ClinicalDecisionSupport
-    from healthchain.data_generator import DataGenerator
+    from healthchain.data_generator import CdsDataGenerator
+    from healthchain.models import Card, CDSRequest, CdsFhirData
     from transformers import pipeline
 
-    from typing import Dict
+    from typing import List
 
     @hc.sandbox
     class MyCoolSandbox(ClinicalDecisionSupport):
         def __init__(self):
-            self.data_generator = DataGenerator()
+            self.data_generator = CdsDataGenerator()
             self.pipeline = pipeline('summarization')
 
-        @hc.ehr(workflow="patient-view")
-        def load_data_in_client(self):
-            self.data_generator.generate()
-            return self.data_generator.data
+        @hc.ehr(workflow="patient-view") -> CdsFhirData
+        def load_data_in_client(self) -> CdsFhirData:
+            data = self.data_generator.generate()
+            return data
 
         @hc.api
-        def my_service(self, text: str):
-            results = self.pipeline(text)
-            return {
-                "cards": [
-                    {
-                        "summary": "Patient summary",
-                        "indicator": "info",
-                        "source": {"label": "transformer"},
-                        "detail": results[0]['summary_text']
-                    }
-                ]
-            }
+        def my_service(self, request: CDSRequest) -> List[Card]:
+            results = self.pipeline(str(request.prefetch))
+            return [
+                Card(
+                    summary="Patient summary",
+                    indicator="info",
+                    source={"label": "transformers"},
+                    detail=results[0]['summary_text'],
+                )
+            ]
 
     if __name__ == "__main__":
         cds = MyCoolSandbox()
@@ -203,49 +218,47 @@ If you are using a model that requires initialisation steps, we recommend you in
     import healthchain as hc
 
     from healthchain.use_cases import ClinicalDecisionSupport
-    from healthchain.data_generator import DataGenerator
+    from healthchain.data_generator import CdsDataGenerator
+    from healthchain.models import Card, CdsFhirData, CDSRequest
 
     from langchain_openai import ChatOpenAI
     from langchain_core.prompts import PromptTemplate
     from langchain_core.output_parsers import StrOutputParser
 
-    from typing import Dict
+    from typing import List
 
     @hc.sandbox
     class MyCoolSandbox(ClinicalDecisionSupport):
         def __init__(self):
             self.chain = self._init_llm_chain()
-            self.data_generator = DataGenerator()
+            self.data_generator = CdsDataGenerator()
 
         def _init_llm_chain(self):
             prompt = PromptTemplate.from_template(
                 "Summarize the text below {text}"
-                )
+            )
             model = ChatOpenAI(model="gpt-4o")
             parser = StrOutputParser()
 
             chain = prompt | model | parser
-
             return chain
 
         @hc.ehr(workflow="patient-view")
-        def load_data_in_client(self):
-            self.data_generator.generate()
-            return self.data_generator.data
+        def load_data_in_client(self) -> CdsFhirData:
+            data = self.data_generator.generate()
+            return data
 
         @hc.api
-        def my_service(self, text: str) -> Dict:
-            result = self.chain.invoke(text)
-            return {
-                "cards": [
-                    {
-                        "summary": "Patient summary",
-                        "indicator": "info",
-                        "source": {"label": "openai"},
-                        "detail": result
-                    }
-                ]
-            }
+        def my_service(self, request: CDSRequest) -> List[Card]:
+            result = self.chain.invoke(str(request.prefetch))
+            return [
+                Card(
+                    summary="Patient summary",
+                    indicator="info",
+                    source={"label": "openai"},
+                    detail=result,
+                )
+            ]
 
     if __name__ == "__main__":
         cds = MyCoolSandbox()

--- a/healthchain/__init__.py
+++ b/healthchain/__init__.py
@@ -1,7 +1,7 @@
 import logging
 from .utils.logger import add_handlers
 from healthchain.decorators import ehr, api, sandbox
-from healthchain.data_generator.data_generator import DataGenerator
+from healthchain.data_generator.data_generator import CDSDataGenerator
 from healthchain.models.requests.cdsrequest import CDSRequest
 
 logger = logging.getLogger(__name__)
@@ -9,4 +9,4 @@ add_handlers(logger)
 logger.setLevel(logging.INFO)
 
 # Export them at the top level
-__all__ = ["ehr", "api", "sandbox", "DataGenerator", "CDSRequest"]
+__all__ = ["ehr", "api", "sandbox", "CDSDataGenerator", "CDSRequest"]

--- a/healthchain/__init__.py
+++ b/healthchain/__init__.py
@@ -1,7 +1,7 @@
 import logging
 from .utils.logger import add_handlers
 from healthchain.decorators import ehr, api, sandbox
-from healthchain.data_generator.data_generator import CDSDataGenerator
+from healthchain.data_generator.data_generator import CdsDataGenerator
 from healthchain.models.requests.cdsrequest import CDSRequest
 
 logger = logging.getLogger(__name__)
@@ -9,4 +9,4 @@ add_handlers(logger)
 logger.setLevel(logging.INFO)
 
 # Export them at the top level
-__all__ = ["ehr", "api", "sandbox", "CDSDataGenerator", "CDSRequest"]
+__all__ = ["ehr", "api", "sandbox", "CdsDataGenerator", "CDSRequest"]

--- a/healthchain/data_generator/__init__.py
+++ b/healthchain/data_generator/__init__.py
@@ -5,7 +5,7 @@ from .practitioner_generators import PractitionerGenerator
 from .procedure_generators import ProcedureGenerator
 from .medication_administration_generators import MedicationAdministrationGenerator
 from .medication_request_generators import MedicationRequestGenerator
-from .data_generator import DataGenerator
+from .data_generator import CDSDataGenerator
 
 __all__ = [
     "EncounterGenerator",
@@ -15,5 +15,5 @@ __all__ = [
     "ProcedureGenerator",
     "MedicationAdministrationGenerator",
     "MedicationRequestGenerator",
-    "DataGenerator",
+    "CDSDataGenerator",
 ]

--- a/healthchain/data_generator/__init__.py
+++ b/healthchain/data_generator/__init__.py
@@ -5,7 +5,7 @@ from .practitioner_generators import PractitionerGenerator
 from .procedure_generators import ProcedureGenerator
 from .medication_administration_generators import MedicationAdministrationGenerator
 from .medication_request_generators import MedicationRequestGenerator
-from .data_generator import CDSDataGenerator
+from .data_generator import CdsDataGenerator
 
 __all__ = [
     "EncounterGenerator",
@@ -15,5 +15,5 @@ __all__ = [
     "ProcedureGenerator",
     "MedicationAdministrationGenerator",
     "MedicationRequestGenerator",
-    "CDSDataGenerator",
+    "CdsDataGenerator",
 ]

--- a/healthchain/data_generator/data_generator.py
+++ b/healthchain/data_generator/data_generator.py
@@ -11,7 +11,7 @@ from healthchain.fhir_resources.document_reference_resources import (
     DocumentReferenceModel,
 )
 from healthchain.fhir_resources.general_purpose_resources import NarrativeModel
-from healthchain.models.data.generatedfhirdata import GeneratedFhirData
+from healthchain.models.data.cdsfhirdata import CdsFhirData
 
 
 workflow_mappings = {
@@ -32,11 +32,11 @@ workflow_mappings = {
 # TODO: Some of the resources should be allowed to be multiplied
 
 
-class CDSDataGenerator:
+class CdsDataGenerator:
     def __init__(self):
         self.registry = generator_registry
         self.mappings = workflow_mappings
-        self.data: GeneratedFhirData = None
+        self.data: CdsFhirData = None
 
     def fetch_generator(self, generator_name: str) -> Callable:
         return self.registry.get(generator_name)
@@ -73,7 +73,7 @@ class CDSDataGenerator:
                     resource=random.choice(parsed_free_text[self.workflow.value])
                 )
             )
-        output = GeneratedFhirData(prefetch=BundleModel(entry=results))
+        output = CdsFhirData(prefetch=BundleModel(entry=results))
         self.data = output
         return output
 

--- a/healthchain/data_generator/data_generator.py
+++ b/healthchain/data_generator/data_generator.py
@@ -1,15 +1,17 @@
+import random
+import json
+
+from pydantic import BaseModel
 from typing import Callable, Optional
+
+from healthchain.base import Workflow
 from healthchain.fhir_resources.bundle_resources import BundleModel, Bundle_EntryModel
 from healthchain.data_generator.base_generators import generator_registry
 from healthchain.fhir_resources.document_reference_resources import (
     DocumentReferenceModel,
 )
 from healthchain.fhir_resources.general_purpose_resources import NarrativeModel
-from healthchain.base import Workflow
-from pydantic import BaseModel
-
-import random
-import json
+from healthchain.models.data.generatedfhirdata import GeneratedFhirData
 
 
 workflow_mappings = {
@@ -30,16 +32,11 @@ workflow_mappings = {
 # TODO: Some of the resources should be allowed to be multiplied
 
 
-class OutputDataModel(BaseModel):
-    context: dict = {}
-    resources: BundleModel
-
-
-class DataGenerator:
+class CDSDataGenerator:
     def __init__(self):
         self.registry = generator_registry
         self.mappings = workflow_mappings
-        self.data = []
+        self.data: GeneratedFhirData = None
 
     def fetch_generator(self, generator_name: str) -> Callable:
         return self.registry.get(generator_name)
@@ -76,7 +73,7 @@ class DataGenerator:
                     resource=random.choice(parsed_free_text[self.workflow.value])
                 )
             )
-        output = OutputDataModel(context={}, resources=BundleModel(entry=results))
+        output = GeneratedFhirData(prefetch=BundleModel(entry=results))
         self.data = output
         return output
 

--- a/healthchain/decorators.py
+++ b/healthchain/decorators.py
@@ -14,7 +14,7 @@ from typing import Any, Type, TypeVar, Optional, Callable, Union, Dict
 from .base import BaseUseCase, Workflow, UseCaseType
 from .clients import EHRClient
 from .service.service import Service
-from .data_generator.data_generator import CDSDataGenerator
+from .data_generator.data_generator import CdsDataGenerator
 from .utils.apimethod import APIMethod
 from .utils.urlbuilder import UrlBuilder
 
@@ -131,7 +131,7 @@ def ehr(
                 )
 
             # Set workflow in data generator if configured
-            data_generator_attributes = find_attributes_of_type(self, CDSDataGenerator)
+            data_generator_attributes = find_attributes_of_type(self, CdsDataGenerator)
             for i in range(len(data_generator_attributes)):
                 attribute_name = data_generator_attributes[i]
                 try:

--- a/healthchain/decorators.py
+++ b/healthchain/decorators.py
@@ -14,7 +14,7 @@ from typing import Any, Type, TypeVar, Optional, Callable, Union, Dict
 from .base import BaseUseCase, Workflow, UseCaseType
 from .clients import EHRClient
 from .service.service import Service
-from .data_generator.data_generator import DataGenerator
+from .data_generator.data_generator import CDSDataGenerator
 from .utils.apimethod import APIMethod
 from .utils.urlbuilder import UrlBuilder
 
@@ -131,7 +131,7 @@ def ehr(
                 )
 
             # Set workflow in data generator if configured
-            data_generator_attributes = find_attributes_of_type(self, DataGenerator)
+            data_generator_attributes = find_attributes_of_type(self, CDSDataGenerator)
             for i in range(len(data_generator_attributes)):
                 attribute_name = data_generator_attributes[i]
                 try:

--- a/healthchain/decorators.py
+++ b/healthchain/decorators.py
@@ -25,13 +25,13 @@ F = TypeVar("F", bound=Callable)
 
 
 def generate_filename(prefix: str, unique_id: str, index: int):
-    timestamp = datetime.now().strftime("%Y-%m-%d")
-    filename = f"{timestamp}_sandbox_{unique_id}_{prefix}_{index}.json"
+    timestamp = datetime.now().strftime("%Y%m%d%H%M")
+    filename = f"{timestamp}_sandbox_{unique_id[:8]}_{prefix}_{index}.json"
     return filename
 
 
 def save_as_json(data, prefix, sandbox_id, index, save_dir):
-    save_name = generate_filename(prefix, sandbox_id, index)
+    save_name = generate_filename(prefix, str(sandbox_id), index)
     file_path = save_dir / save_name
     with open(file_path, "w") as outfile:
         json.dump(data, outfile, indent=4)

--- a/healthchain/decorators.py
+++ b/healthchain/decorators.py
@@ -25,7 +25,7 @@ F = TypeVar("F", bound=Callable)
 
 
 def generate_filename(prefix: str, unique_id: str, index: int):
-    timestamp = datetime.now().strftime("%Y%m%d%H%M")
+    timestamp = datetime.now().strftime("%Y-%m-%d")
     filename = f"{timestamp}_sandbox_{unique_id[:8]}_{prefix}_{index}.json"
     return filename
 

--- a/healthchain/models/__init__.py
+++ b/healthchain/models/__init__.py
@@ -1,0 +1,6 @@
+from .requests.cdsrequest import CDSRequest
+from .responses.cdsresponse import Card
+from .responses.cdsresponse import CDSResponse
+from .responses.cdsdiscovery import CDSService
+
+__all__ = ["CDSRequest", "Card", "CDSResponse", "CDSService"]

--- a/healthchain/models/__init__.py
+++ b/healthchain/models/__init__.py
@@ -2,6 +2,6 @@ from .requests.cdsrequest import CDSRequest
 from .responses.cdsresponse import Card
 from .responses.cdsresponse import CDSResponse
 from .responses.cdsdiscovery import CDSService
-from .data.generatedfhirdata import GeneratedFhirData
+from .data.cdsfhirdata import CdsFhirData
 
-__all__ = ["CDSRequest", "Card", "CDSResponse", "CDSService", "GeneratedFhirData"]
+__all__ = ["CDSRequest", "Card", "CDSResponse", "CDSService", "CdsFhirData"]

--- a/healthchain/models/__init__.py
+++ b/healthchain/models/__init__.py
@@ -2,5 +2,6 @@ from .requests.cdsrequest import CDSRequest
 from .responses.cdsresponse import Card
 from .responses.cdsresponse import CDSResponse
 from .responses.cdsdiscovery import CDSService
+from .data.generatedfhirdata import GeneratedFhirData
 
-__all__ = ["CDSRequest", "Card", "CDSResponse", "CDSService"]
+__all__ = ["CDSRequest", "Card", "CDSResponse", "CDSService", "GeneratedFhirData"]

--- a/healthchain/models/data/cdsfhirdata.py
+++ b/healthchain/models/data/cdsfhirdata.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel, Field
+from typing import Dict
+
+from ...fhir_resources.bundle_resources import BundleModel
+
+
+class CdsFhirData(BaseModel):
+    context: Dict = Field(default={})
+    prefetch: BundleModel
+
+    def model_dump(self, *args, **kwargs):
+        kwargs.setdefault("exclude_unset", True)
+        kwargs.setdefault("exclude_none", True)
+        kwargs.setdefault("by_alias", True)
+
+        return super().model_dump(*args, **kwargs)

--- a/healthchain/models/data/generatedfhirdata.py
+++ b/healthchain/models/data/generatedfhirdata.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel, Field
+from typing import Dict
+
+from ...fhir_resources.bundle_resources import BundleModel
+
+
+class GeneratedFhirData(BaseModel):
+    context: Dict = Field(default={})
+    prefetch: BundleModel

--- a/healthchain/models/data/generatedfhirdata.py
+++ b/healthchain/models/data/generatedfhirdata.py
@@ -1,9 +1,0 @@
-from pydantic import BaseModel, Field
-from typing import Dict
-
-from ...fhir_resources.bundle_resources import BundleModel
-
-
-class GeneratedFhirData(BaseModel):
-    context: Dict = Field(default={})
-    prefetch: BundleModel

--- a/healthchain/use_cases/cds.py
+++ b/healthchain/use_cases/cds.py
@@ -20,7 +20,7 @@ from ..models.hooks.orderselect import OrderSelectContext
 from ..models.hooks.ordersign import OrderSignContext
 from ..models.hooks.patientview import PatientViewContext
 from ..models.hooks.encounterdischarge import EncounterDischargeContext
-from ..data_generator.data_generator import GeneratedFhirData
+from ..data_generator.data_generator import CdsFhirData
 from ..utils.endpoints import Endpoint
 from ..utils.apimethod import APIMethod
 from ..utils.urlbuilder import UrlBuilder
@@ -42,9 +42,7 @@ class ClinicalDecisionSupportStrategy(BaseStrategy):
         }
 
     @validate_workflow(UseCaseMapping.ClinicalDecisionSupport)
-    def construct_request(
-        self, data: GeneratedFhirData, workflow: Workflow
-    ) -> CDSRequest:
+    def construct_request(self, data: CdsFhirData, workflow: Workflow) -> CDSRequest:
         """
         Constructs a HL7-compliant CDS request based on workflow.
 
@@ -168,13 +166,9 @@ class ClinicalDecisionSupport(BaseUseCase):
         for name, param in params:
             if name != "self":
                 if param.annotation == str:
-                    service_input = request.model_dump_json(
-                        exclude_none=True, exclude_unset=True, by_alias=True
-                    )
+                    service_input = request.model_dump_json(exclude_none=True)
                 elif param.annotation == Dict:
-                    service_input = request.model_dump(
-                        exclude_none=True, exclude_unset=True, by_alias=True
-                    )
+                    service_input = request.model_dump(exclude_none=True)
 
         result = self.service_api.func(self, service_input)
 

--- a/healthchain/use_cases/cds.py
+++ b/healthchain/use_cases/cds.py
@@ -20,6 +20,7 @@ from ..models.hooks.orderselect import OrderSelectContext
 from ..models.hooks.ordersign import OrderSignContext
 from ..models.hooks.patientview import PatientViewContext
 from ..models.hooks.encounterdischarge import EncounterDischargeContext
+from ..data_generator.data_generator import GeneratedFhirData
 from ..utils.endpoints import Endpoint
 from ..utils.apimethod import APIMethod
 from ..utils.urlbuilder import UrlBuilder
@@ -41,7 +42,9 @@ class ClinicalDecisionSupportStrategy(BaseStrategy):
         }
 
     @validate_workflow(UseCaseMapping.ClinicalDecisionSupport)
-    def construct_request(self, data, workflow: Workflow) -> CDSRequest:
+    def construct_request(
+        self, data: GeneratedFhirData, workflow: Workflow
+    ) -> CDSRequest:
         """
         Constructs a HL7-compliant CDS request based on workflow.
 
@@ -66,7 +69,7 @@ class ClinicalDecisionSupportStrategy(BaseStrategy):
         request = CDSRequest(
             hook=workflow.value,
             context=context,
-            prefetch=data.resources.model_dump(
+            prefetch=data.prefetch.model_dump(
                 exclude_none=True, exclude_unset=True, by_alias=True
             ),
         )

--- a/healthchain/use_cases/cds.py
+++ b/healthchain/use_cases/cds.py
@@ -182,7 +182,17 @@ class ClinicalDecisionSupport(BaseUseCase):
                 "CDS 'service_api' returned None, please check function definition."
             )
             return CDSResponse(cards=[])
-        elif isinstance(result, Card):
-            result = [result]
+
+        if not isinstance(result, list):
+            if isinstance(result, Card):
+                result = [result]
+            else:
+                raise TypeError(f"Expected a list, but got {type(result).__name__}")
+
+        for card in result:
+            if not isinstance(card, Card):
+                raise TypeError(
+                    f"Expected a list of 'Card' objects, but found an item of type {type(card).__name__}"
+                )
 
         return CDSResponse(cards=result)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,12 +20,12 @@ class MockBundle(BaseModel):
 @dataclasses.dataclass
 class synth_data:
     context: dict
-    resources: MockBundle
+    prefetch: MockBundle
 
 
 class MockDataGenerator:
     def __init__(self) -> None:
-        self.data = synth_data(context={}, resources=MockBundle())
+        self.data = synth_data(context={}, prefetch=MockBundle())
         self.workflow = None
 
     def set_workflow(self, workflow):
@@ -41,7 +41,7 @@ def cds_strategy():
 def valid_data():
     return synth_data(
         context={"userId": "Practitioner/123", "patientId": "123"},
-        resources=MockBundle(),
+        prefetch=MockBundle(),
     )
 
 
@@ -49,7 +49,7 @@ def valid_data():
 def invalid_data():
     return synth_data(
         context={"invalidId": "Practitioner", "patientId": "123"},
-        resources=MockBundle(),
+        prefetch=MockBundle(),
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,8 @@ from unittest.mock import Mock
 from pydantic import BaseModel
 
 from healthchain.base import BaseStrategy, BaseUseCase, UseCaseType
+from healthchain.fhir_resources.bundle_resources import Bundle_EntryModel, BundleModel
+from healthchain.models.data.cdsfhirdata import CdsFhirData
 from healthchain.models.requests.cdsrequest import CDSRequest
 from healthchain.use_cases.cds import ClinicalDecisionSupportStrategy
 from healthchain.clients import EHRClient
@@ -25,7 +27,10 @@ class synth_data:
 
 class MockDataGenerator:
     def __init__(self) -> None:
-        self.data = synth_data(context={}, prefetch=MockBundle())
+        self.data = CdsFhirData(
+            context={}, prefetch=BundleModel(entry=[Bundle_EntryModel()])
+        )
+        # self.data = synth_data(context={}, prefetch=MockBundle())
         self.workflow = None
 
     def set_workflow(self, workflow):
@@ -39,17 +44,17 @@ def cds_strategy():
 
 @pytest.fixture
 def valid_data():
-    return synth_data(
+    return CdsFhirData(
         context={"userId": "Practitioner/123", "patientId": "123"},
-        prefetch=MockBundle(),
+        prefetch=BundleModel(entry=[Bundle_EntryModel()]),
     )
 
 
 @pytest.fixture
 def invalid_data():
-    return synth_data(
+    return CdsFhirData(
         context={"invalidId": "Practitioner", "patientId": "123"},
-        prefetch=MockBundle(),
+        prefetch=BundleModel(entry=[Bundle_EntryModel()]),
     )
 
 

--- a/tests/generators_tests/test_data_generator.py
+++ b/tests/generators_tests/test_data_generator.py
@@ -1,36 +1,36 @@
 from healthchain.data_generator.data_generator import (
-    DataGenerator,
+    CDSDataGenerator,
 )
 from healthchain.base import Workflow
 import pytest
 
 
 def test_generator_orchestrator_encounter_discharge():
-    generator = DataGenerator()
+    generator = CDSDataGenerator()
 
     workflow = Workflow.encounter_discharge
     generator.set_workflow(workflow=workflow)
     generator.generate()
 
-    assert len(generator.data.model_dump(by_alias=True)["resources"]["entry"]) == 4
+    assert len(generator.data.model_dump(by_alias=True)["prefetch"]["entry"]) == 4
 
 
 def test_generator_orchestrator_patient_view():
-    generator = DataGenerator()
+    generator = CDSDataGenerator()
 
     workflow = Workflow.patient_view
     generator.set_workflow(workflow=workflow)
     generator.generate()
 
-    assert len(generator.data.model_dump(by_alias=True)["resources"]["entry"]) == 3
+    assert len(generator.data.model_dump(by_alias=True)["prefetch"]["entry"]) == 3
 
 
 @pytest.mark.skip()
 def test_generator_with_json():
-    generator = DataGenerator()
+    generator = CDSDataGenerator()
 
     workflow = Workflow.patient_view
     generator.set_workflow(workflow=workflow)
     generator.generate(free_text_json="use_cases/example_free_text.json")
 
-    assert len(generator.data.model_dump(by_alias=True)["resources"]["entry"]) == 4
+    assert len(generator.data.model_dump(by_alias=True)["prefetch"]["entry"]) == 4

--- a/tests/generators_tests/test_data_generator.py
+++ b/tests/generators_tests/test_data_generator.py
@@ -1,12 +1,12 @@
 from healthchain.data_generator.data_generator import (
-    CDSDataGenerator,
+    CdsDataGenerator,
 )
 from healthchain.base import Workflow
 import pytest
 
 
 def test_generator_orchestrator_encounter_discharge():
-    generator = CDSDataGenerator()
+    generator = CdsDataGenerator()
 
     workflow = Workflow.encounter_discharge
     generator.set_workflow(workflow=workflow)
@@ -16,7 +16,7 @@ def test_generator_orchestrator_encounter_discharge():
 
 
 def test_generator_orchestrator_patient_view():
-    generator = CDSDataGenerator()
+    generator = CdsDataGenerator()
 
     workflow = Workflow.patient_view
     generator.set_workflow(workflow=workflow)
@@ -27,7 +27,7 @@ def test_generator_orchestrator_patient_view():
 
 @pytest.mark.skip()
 def test_generator_with_json():
-    generator = CDSDataGenerator()
+    generator = CdsDataGenerator()
 
     workflow = Workflow.patient_view
     generator.set_workflow(workflow=workflow)

--- a/tests/integration_tests/test_full_workflow.py
+++ b/tests/integration_tests/test_full_workflow.py
@@ -1,6 +1,6 @@
 from healthchain.use_cases.cds import ClinicalDecisionSupport
 from healthchain.decorators import ehr, api, sandbox
-from healthchain.data_generator.data_generator import CDSDataGenerator
+from healthchain.data_generator.data_generator import CdsDataGenerator
 from healthchain.models.requests.cdsrequest import CDSRequest
 import json
 import pytest
@@ -11,7 +11,7 @@ def test_run():
     @sandbox(service_config={"port": 9000})
     class myCDS(ClinicalDecisionSupport):
         def __init__(self) -> None:
-            self.data_generator = CDSDataGenerator()
+            self.data_generator = CdsDataGenerator()
             self.chain = self.define_chain()
 
         def define_chain(self):

--- a/tests/integration_tests/test_full_workflow.py
+++ b/tests/integration_tests/test_full_workflow.py
@@ -1,6 +1,6 @@
 from healthchain.use_cases.cds import ClinicalDecisionSupport
 from healthchain.decorators import ehr, api, sandbox
-from healthchain.data_generator.data_generator import DataGenerator
+from healthchain.data_generator.data_generator import CDSDataGenerator
 from healthchain.models.requests.cdsrequest import CDSRequest
 import json
 import pytest
@@ -11,7 +11,7 @@ def test_run():
     @sandbox(service_config={"port": 9000})
     class myCDS(ClinicalDecisionSupport):
         def __init__(self) -> None:
-            self.data_generator = DataGenerator()
+            self.data_generator = CDSDataGenerator()
             self.chain = self.define_chain()
 
         def define_chain(self):

--- a/tests/test_cds.py
+++ b/tests/test_cds.py
@@ -34,6 +34,7 @@ def test_cds_service_no_api_set(test_cds_request):
 
 
 def test_cds_service(cds, test_cds_request):
+    # test returning list of cards
     request = test_cds_request
     cds.service_api.func.return_value = [
         Card(
@@ -46,6 +47,24 @@ def test_cds_service(cds, test_cds_request):
     assert len(response.cards) == 1
     assert response.cards[0].summary == "example"
     assert response.cards[0].indicator == "info"
+
+    # test returning single card
+    cds.service_api.func.return_value = Card(
+        summary="example",
+        indicator="info",
+        source={"label": "test"},
+    )
+    response = cds.cds_service("1", request)
+    assert len(response.cards) == 1
+    assert response.cards[0].summary == "example"
+    assert response.cards[0].indicator == "info"
+
+
+def test_cds_service_incorrect_return_type(cds, test_cds_request):
+    request = test_cds_request
+    cds.service_api.func.return_value = "this is not a valid return type"
+    with pytest.raises(TypeError):
+        cds.cds_service("1", request)
 
 
 def func_zero_params():

--- a/tests/test_cds.py
+++ b/tests/test_cds.py
@@ -2,6 +2,7 @@ import pytest
 
 from unittest.mock import Mock
 from healthchain.use_cases.cds import ClinicalDecisionSupport
+from healthchain.models import Card
 
 
 def test_initialization(cds):
@@ -34,15 +35,13 @@ def test_cds_service_no_api_set(test_cds_request):
 
 def test_cds_service(cds, test_cds_request):
     request = test_cds_request
-    cds.service_api.func.return_value = {
-        "cards": [
-            {
-                "summary": "example",
-                "indicator": "info",
-                "source": {"label": "website"},
-            }
-        ]
-    }
+    cds.service_api.func.return_value = [
+        Card(
+            summary="example",
+            indicator="info",
+            source={"label": "test"},
+        )
+    ]
     response = cds.cds_service("1", request)
     assert len(response.cards) == 1
     assert response.cards[0].summary == "example"

--- a/tests/test_service_with_func.py
+++ b/tests/test_service_with_func.py
@@ -21,7 +21,7 @@ class myCDS(ClinicalDecisionSupport):
     def llm(self, text: str):
         return [
             Card(
-                summary=self.data_generator.data.prefetch.condition,
+                summary="test",
                 indicator="info",
                 source={"label": "website"},
             )

--- a/tests/test_service_with_func.py
+++ b/tests/test_service_with_func.py
@@ -21,7 +21,7 @@ class myCDS(ClinicalDecisionSupport):
     def llm(self, text: str):
         return [
             Card(
-                summary=self.data_generator.data.resources.condition,
+                summary=self.data_generator.data.prefetch.condition,
                 indicator="info",
                 source={"label": "website"},
             )

--- a/tests/test_service_with_func.py
+++ b/tests/test_service_with_func.py
@@ -4,6 +4,7 @@ from fastapi.testclient import TestClient
 from .conftest import MockDataGenerator
 from healthchain.decorators import sandbox, ehr, api
 from healthchain.use_cases.cds import ClinicalDecisionSupport
+from healthchain.models import Card
 
 
 @sandbox
@@ -18,15 +19,13 @@ class myCDS(ClinicalDecisionSupport):
 
     @api
     def llm(self, text: str):
-        return {
-            "cards": [
-                {
-                    "summary": self.data_generator.data.resources.condition,
-                    "indicator": "info",
-                    "source": {"label": "website"},
-                }
-            ]
-        }
+        return [
+            Card(
+                summary=self.data_generator.data.resources.condition,
+                indicator="info",
+                source={"label": "website"},
+            )
+        ]
 
 
 cds = myCDS()

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -13,7 +13,7 @@ def test_valid_data_request_construction(cds_strategy, valid_data):
         mock_init.assert_called_once_with(
             hook=Workflow.patient_view.value,
             context=PatientViewContext(userId="Practitioner/123", patientId="123"),
-            prefetch={},
+            prefetch={"entry": [{}]},
         )
 
 


### PR DESCRIPTION
Addresses https://github.com/dotimplement/HealthChain/issues/30

### CHANGES
- Renamed `DataGenerator` to `CdsDataGenrator` - as the behaviour is highly specific to CDS FHIR generation so we might add other types of data generators.
- Refactored `OutputDataGenerator` to `CdsFhirData` in `models/data` with default empty dict for `context` field and renamed `resource` field to `prefetch` for consistency. Also set default `model_dump` behaviour - `exclude_none=True, exclude_unset=True, by_alias=True`
- More explicit function I/O in usage for service and client functions:
    - ehr client must return `CdsFhirData` Pydantic model
    - service takes in `CdsRequest` Pydantic model (although through type hinting it can also dynamically convert this model to `str` or `Dict`, but it's more of a fallback as it's better to keep consistent and use the pydantic model)
    - service returns a list of `Card` Pydantic model (if a single `Card` is returned, the wrapper will put it in a list)
 - Updated documentation
 - shorten sandbox id in save name

Tasks
- [x] Make service func io more explicit
- [x] Make client func io more explicit
- [x] Raise errors to check correct data type is being passed
- [x] Update documentation