### PR TITLE
Add current time to output filename.

### DIFF
--- a/healthchain/decorators.py
+++ b/healthchain/decorators.py
@@ -25,7 +25,7 @@ F = TypeVar("F", bound=Callable)
 
 
 def generate_filename(prefix: str, unique_id: str, index: int):
-    timestamp = datetime.now().strftime("%Y-%m-%d")
+    timestamp = datetime.now().strftime("%Y-%m-%d_%H:%M:%S")
     filename = f"{timestamp}_sandbox_{unique_id}_{prefix}_{index}.json"
     return filename
 


### PR DESCRIPTION
Fixes https://github.com/dotimplement/HealthChain/issues/42

Adds current time to output filename in decorators.py, no timezone specified.