### PR TITLE
Add random seed to ensure reproducibility

### DIFF
--- a/healthchain/data_generators/cdsdatagenerator.py
+++ b/healthchain/data_generators/cdsdatagenerator.py
@@ -75,6 +75,7 @@ class CdsDataGenerator:
         constraints: Optional[list] = None,
         free_text_path: Optional[str] = None,
         column_name: Optional[str] = None,
+        random_seed: Optional[int] = None,
     ) -> BaseModel:
         """
         Generates CDS data based on the current workflow, constraints, and optional free text data.
@@ -83,6 +84,7 @@ class CdsDataGenerator:
             constraints (Optional[list]): A list of constraints to apply to the data generation.
             free_text_path (Optional[str]): The path to a CSV file containing free text data.
             column_name (Optional[str]): The column name in the CSV file to use for free text data.
+            random_seed (Optional[int]): The random seed to use for reproducible data generation.
 
         Returns:
             BaseModel: The generated CDS FHIR data.
@@ -95,7 +97,9 @@ class CdsDataGenerator:
         for resource in self.mappings[self.workflow]:
             generator_name = resource["generator"]
             generator = self.fetch_generator(generator_name)
-            result = generator.generate(constraints=constraints)
+            result = generator.generate(
+                constraints=constraints, random_seed=random_seed
+            )
 
             results.append(BundleEntry(resource=result))
 

--- a/healthchain/data_generators/conditiongenerators.py
+++ b/healthchain/data_generators/conditiongenerators.py
@@ -147,7 +147,9 @@ class ConditionGenerator(BaseGenerator):
         subject_reference: Optional[str] = None,
         encounter_reference: Optional[str] = None,
         constraints: Optional[list] = None,
+        random_seed: Optional[int] = None,
     ):
+        Faker.seed(random_seed)
         subject_reference = subject_reference or "Patient/123"
         encounter_reference = encounter_reference or "Encounter/123"
         code = generator_registry.get("SnomedCodeGenerator").generate(

--- a/healthchain/data_generators/encountergenerators.py
+++ b/healthchain/data_generators/encountergenerators.py
@@ -143,14 +143,16 @@ class EncounterGenerator(BaseGenerator):
     A generator class for creating FHIR Encounter resources.
 
     Methods:
-        generate(constraints: Optional[list] = None) -> Encounter:
-            Generates a FHIR Encounter resource with optional constraints.
+        generate(constraints: Optional[list] = None, random_seed: Optional[int] = None) -> Encounter:
+            Generates a FHIR Encounter resource with optional constraints and random_seed.
     """
 
     @staticmethod
     def generate(
         constraints: Optional[list] = None,
+        random_seed: Optional[int] = None,
     ) -> Encounter:
+        Faker.seed(random_seed)
         patient_reference = "Patient/123"
         return Encounter(
             resourceType="Encounter",

--- a/healthchain/data_generators/medicationrequestgenerators.py
+++ b/healthchain/data_generators/medicationrequestgenerators.py
@@ -46,7 +46,9 @@ class MedicationRequestGenerator(BaseGenerator):
     @staticmethod
     def generate(
         constraints: Optional[list] = None,
+        random_seed: Optional[int] = None,
     ):
+        Faker.seed(random_seed)
         subject_reference = "Patient/123"
         encounter_reference = "Encounter/123"
         contained_medication = Medication(

--- a/healthchain/data_generators/patientgenerators.py
+++ b/healthchain/data_generators/patientgenerators.py
@@ -116,7 +116,11 @@ class HumanNameGenerator(BaseGenerator):
 @register_generator
 class PatientGenerator(BaseGenerator):
     @staticmethod
-    def generate(constraints: Optional[list] = None):
+    def generate(
+        constraints: Optional[list] = None,
+        random_seed: Optional[int] = None,
+    ) -> Patient:
+        Faker.seed(random_seed)
         return Patient(
             resourceType="Patient",
             id=generator_registry.get("IdGenerator").generate(),

--- a/healthchain/data_generators/proceduregenerators.py
+++ b/healthchain/data_generators/proceduregenerators.py
@@ -42,7 +42,9 @@ class ProcedureGenerator(BaseGenerator):
         subject_reference: Optional[str] = None,
         encounter_reference: Optional[str] = None,
         constraints: Optional[list] = None,
+        random_seed: Optional[int] = None,
     ):
+        Faker.seed(random_seed)
         subject_reference = subject_reference or "Patient/123"
         encounter_reference = encounter_reference or "Encounter/123"
         code = generator_registry.get("ProcedureSnomedCodeGenerator").generate(


### PR DESCRIPTION
## Description
Added random_seed parameter to data_generator

## Related Issue
#20 

## Changes Made
<!-- List the key changes made in this PR -->

- Added parameter random_seed in generate() function of CdsDataGenerator, EncounterGenerator, ConditionGenerator, ProcedureGenerator, MedicationRequestGenerator, PatientGenerator
- Used Faker.seed() method

## Testing
<!-- Describe how these changes were tested -->
Tested by generating data according to documentation multiple time with same seed
```
from healthchain.data_generators import CdsDataGenerator
from healthchain.base import Workflow

# Initialise data generator
data_generator = CdsDataGenerator()

# Generate FHIR resources for use case workflow
data_generator.set_workflow(Workflow.encounter_discharge)
data = data_generator.generate(random_seed=42)

print(data.model_dump())
```

## Checklist
<!-- Mark the items you've completed with an [x] -->

- [x] I have read the [contributing](https://github.com/dotimplement/HealthChain/CONTRIBUTING.md) guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Add any other context about the PR here -->
Though the generated date of faker.date_time() remains same for a fixed seed, generated time differs. This may affect reproducibility.

