### PR TITLE
Bodysite bugfix

### DIFF
--- a/healthchain/data_generators/conditiongenerators.py
+++ b/healthchain/data_generators/conditiongenerators.py
@@ -95,8 +95,8 @@ class BodySiteGenerator(BaseGenerator):
     @staticmethod
     def generate():
         return create_single_codeable_concept(
-            code=faker.random_element(elements=("38266002")),
-            display=faker.random_element(elements=("Entire body as a whole")),
+            code=faker.random_element(elements=("38266002",)),
+            display=faker.random_element(elements=("Entire body as a whole",)),
             system="http://snomed.info/sct",
         )
 


### PR DESCRIPTION
## Description
The Faker random element method requires a tuple provided with more than one element. If one string is provided, it chooses a random character from the string. This PR fixes the issue by adding commas to the set of elements. 

## Related Issue
#115 

## Changes Made
Added two commas to select element from tuple properly

## Testing
Tested the Faker function locally.

## Checklist

- [x] I have read the [contributing](https://github.com/dotimplement/HealthChain/CONTRIBUTING.md) guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Add any other context about the PR here -->
