### PR TITLE
Add file, bytes, and directory input sources to BaseParser

### DIFF
--- a/healthchain/interop/parsers/base.py
+++ b/healthchain/interop/parsers/base.py
@@ -1,4 +1,6 @@
 from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import List, Union
 
 from healthchain.interop.config_manager import InteropConfigManager
 
@@ -23,3 +25,55 @@ class BaseParser(ABC):
             A dictionary containing the parsed data structure
         """
         pass
+
+    def from_bytes(self, data: bytes, encoding: str = "utf-8") -> dict:
+        """Parse input data from bytes.
+
+        Args:
+            data: The input data as bytes
+            encoding: Character encoding to use when decoding bytes
+
+        Returns:
+            A dictionary containing the parsed data structure
+        """
+        return self.from_string(data.decode(encoding))
+
+    def from_file(self, file_path: Union[str, Path]) -> dict:
+        """Parse input data from a file.
+
+        Args:
+            file_path: Path to the file to parse
+
+        Returns:
+            A dictionary containing the parsed data structure
+
+        Raises:
+            FileNotFoundError: If the file does not exist
+        """
+        path = Path(file_path)
+        return self.from_string(path.read_text(encoding="utf-8"))
+
+    def from_directory(
+        self, directory_path: Union[str, Path], pattern: str = "*.xml"
+    ) -> List[dict]:
+        """Parse all matching files in a directory.
+
+        Args:
+            directory_path: Path to the directory containing files to parse
+            pattern: Glob pattern to match files (default: "*.xml")
+
+        Returns:
+            A list of dictionaries, one per parsed file
+
+        Raises:
+            NotADirectoryError: If the path is not a directory
+        """
+        path = Path(directory_path)
+        if not path.is_dir():
+            raise NotADirectoryError(f"Not a directory: {path}")
+
+        results = []
+        for file_path in sorted(path.glob(pattern)):
+            if file_path.is_file():
+                results.append(self.from_file(file_path))
+        return results


### PR DESCRIPTION
## Summary

Closes #122

Adds convenience methods to `BaseParser` for loading data from multiple input sources. All methods delegate to the existing `from_string()` method, so subclass parsers (e.g., `CDAParser`) get these capabilities automatically.

## Changes

- `from_bytes(data, encoding)` — decode bytes to string, then parse
- `from_file(file_path)` — read a file and parse its contents
- `from_directory(directory_path, pattern)` — glob-match files in a directory and parse each one

## Note

The `from_url()` method from the issue is deliberately omitted — it would require adding an HTTP client dependency (`httpx` or `requests`) and has security implications (SSRF) that warrant a separate discussion. Happy to add it as a follow-up if there's a preferred HTTP client.

## Test plan

- [x] All 719 existing tests pass (`uv run pytest`)
- [x] Linter passes (`uv run ruff check . --fix && uv run ruff format .`)