### PR TITLE
[codex] feat(runtime): harden document, config, and execution surfaces

### DIFF
--- a/healthchain/config/appconfig.py
+++ b/healthchain/config/appconfig.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import List, Optional
 
 import yaml
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 logger = logging.getLogger(__name__)
 
@@ -36,8 +36,8 @@ class TLSConfig(BaseModel):
 
 class SecurityConfig(BaseModel):
     auth: str = "none"
-    tls: TLSConfig = TLSConfig()
-    allowed_origins: List[str] = ["*"]
+    tls: TLSConfig = Field(default_factory=TLSConfig)
+    allowed_origins: List[str] = Field(default_factory=lambda: ["*"])
 
     @field_validator("auth")
     @classmethod
@@ -57,7 +57,13 @@ class EvalConfig(BaseModel):
     enabled: bool = False
     provider: str = "mlflow"
     tracking_uri: str = "./mlruns"
-    track: List[str] = ["model_inference", "cds_card_returned", "card_feedback"]
+    track: List[str] = Field(
+        default_factory=lambda: [
+            "model_inference",
+            "cds_card_returned",
+            "card_feedback",
+        ]
+    )
 
 
 class SiteConfig(BaseModel):
@@ -75,15 +81,103 @@ class SiteConfig(BaseModel):
         return v
 
 
+class ApplicationSettings(BaseModel):
+    name: str
+    version: str
+    environment: str
+    site_name: str = ""
+
+
+class RuntimeSettings(BaseModel):
+    service_type: str
+    port: int
+    auth: str
+    tls_enabled: bool
+    allowed_origins: List[str] = Field(default_factory=list)
+
+
+class IntegrationSettings(BaseModel):
+    patients_dir: str
+    output_dir: str
+    eval_enabled: bool
+    eval_provider: str
+
+
+class StartupValidationSummary(BaseModel):
+    status: str
+    config_path: Optional[str] = None
+    application: ApplicationSettings
+    runtime: RuntimeSettings
+    integrations: IntegrationSettings
+    warnings: List[str] = Field(default_factory=list)
+    errors: List[str] = Field(default_factory=list)
+
+
 class AppConfig(BaseModel):
     name: str = "my-healthchain-app"
     version: str = "1.0.0"
-    service: ServiceConfig = ServiceConfig()
-    data: DataConfig = DataConfig()
-    security: SecurityConfig = SecurityConfig()
-    compliance: ComplianceConfig = ComplianceConfig()
-    eval: EvalConfig = EvalConfig()
-    site: SiteConfig = SiteConfig()
+    service: ServiceConfig = Field(default_factory=ServiceConfig)
+    data: DataConfig = Field(default_factory=DataConfig)
+    security: SecurityConfig = Field(default_factory=SecurityConfig)
+    compliance: ComplianceConfig = Field(default_factory=ComplianceConfig)
+    eval: EvalConfig = Field(default_factory=EvalConfig)
+    site: SiteConfig = Field(default_factory=SiteConfig)
+
+    @model_validator(mode="after")
+    def validate_runtime_contract(self) -> "AppConfig":
+        if self.security.tls.enabled and (
+            not self.security.tls.cert_path or not self.security.tls.key_path
+        ):
+            raise ValueError(
+                "security.tls requires both cert_path and key_path when tls.enabled is true"
+            )
+        return self
+
+    @property
+    def application_settings(self) -> ApplicationSettings:
+        return ApplicationSettings(
+            name=self.name,
+            version=self.version,
+            environment=self.site.environment,
+            site_name=self.site.name,
+        )
+
+    @property
+    def runtime_settings(self) -> RuntimeSettings:
+        return RuntimeSettings(
+            service_type=self.service.type,
+            port=self.service.port,
+            auth=self.security.auth,
+            tls_enabled=self.security.tls.enabled,
+            allowed_origins=list(self.security.allowed_origins),
+        )
+
+    @property
+    def integration_settings(self) -> IntegrationSettings:
+        return IntegrationSettings(
+            patients_dir=self.data.patients_dir,
+            output_dir=self.data.output_dir,
+            eval_enabled=self.eval.enabled,
+            eval_provider=self.eval.provider,
+        )
+
+    def build_startup_validation_summary(
+        self,
+        config_path: Optional[Path] = None,
+        *,
+        status: str = "valid",
+        warnings: Optional[List[str]] = None,
+        errors: Optional[List[str]] = None,
+    ) -> StartupValidationSummary:
+        return StartupValidationSummary(
+            status=status,
+            config_path=str(config_path) if config_path else None,
+            application=self.application_settings,
+            runtime=self.runtime_settings,
+            integrations=self.integration_settings,
+            warnings=warnings or [],
+            errors=errors or [],
+        )
 
     @classmethod
     def from_yaml(cls, path: Path) -> "AppConfig":
@@ -93,12 +187,39 @@ class AppConfig(BaseModel):
         return cls(**data)
 
     @classmethod
-    def load(cls) -> Optional["AppConfig"]:
+    def load_with_summary(
+        cls, path: Optional[Path] = None, *, strict: bool = False
+    ) -> tuple[Optional["AppConfig"], StartupValidationSummary]:
+        config_path = path or Path(_CONFIG_FILENAME)
+        if not config_path.exists():
+            default_config = cls()
+            summary = default_config.build_startup_validation_summary(
+                config_path,
+                status="defaulted",
+                warnings=[
+                    f"{config_path.name} not found; runtime will use HealthChain defaults."
+                ],
+            )
+            return None, summary
+
+        try:
+            config = cls.from_yaml(config_path)
+        except Exception as exc:
+            message = f"Failed to load {config_path.name}: {exc}"
+            summary = cls().build_startup_validation_summary(
+                config_path,
+                status="invalid",
+                errors=[message],
+            )
+            if strict:
+                raise ValueError(message) from exc
+            logger.warning(message)
+            return None, summary
+
+        return config, config.build_startup_validation_summary(config_path)
+
+    @classmethod
+    def load(cls, *, strict: bool = False) -> Optional["AppConfig"]:
         """Load healthchain.yaml from the current working directory if it exists."""
-        config_path = Path(_CONFIG_FILENAME)
-        if config_path.exists():
-            try:
-                return cls.from_yaml(config_path)
-            except Exception as e:
-                logger.warning(f"Failed to load {_CONFIG_FILENAME}: {e}")
-        return None
+        config, _summary = cls.load_with_summary(strict=strict)
+        return config

--- a/healthchain/config/base.py
+++ b/healthchain/config/base.py
@@ -1,6 +1,7 @@
 import yaml
 import logging
 import os
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, Any, Optional, List
 
@@ -100,6 +101,19 @@ class ValidationLevel:
     IGNORE = "ignore"  # Skip validation entirely
 
 
+@dataclass
+class ConfigValidationSummary:
+    config_dir: str
+    environment: str
+    module: Optional[str] = None
+    warnings: List[str] = field(default_factory=list)
+    errors: List[str] = field(default_factory=list)
+
+    @property
+    def valid(self) -> bool:
+        return not self.errors
+
+
 class ConfigManager:
     """Manages loading and accessing configuration files for the HealthChain project
 
@@ -137,6 +151,8 @@ class ConfigManager:
         self._module_configs = {}
         self._mappings = {}
         self._loaded = False
+        self._environment_warning: Optional[str] = None
+        self._last_validation_summary: Optional[ConfigValidationSummary] = None
         self._environment = self._detect_environment()
 
     def _detect_environment(self) -> str:
@@ -151,7 +167,10 @@ class ConfigManager:
         # Validate environment
         valid_envs = ["development", "testing", "production"]
         if env not in valid_envs:
-            log.warning(f"Invalid environment '{env}', defaulting to 'development'")
+            self._environment_warning = (
+                f"Invalid HEALTHCHAIN_ENV '{env}', defaulting to 'development'"
+            )
+            log.warning(self._environment_warning)
             env = "development"
 
         log.info(f"Detected environment: {env}")
@@ -473,8 +492,58 @@ class ConfigManager:
 
     def validate(self) -> bool:
         """Validate that all required configurations are present"""
-        # TODO: Implement validation
+        summary = self.get_validation_summary()
+        if summary.errors:
+            return self._handle_validation_error("; ".join(summary.errors))
         return True
+
+    def get_validation_summary(self) -> ConfigValidationSummary:
+        """Build a validation summary for loaded configuration surfaces."""
+        summary = ConfigValidationSummary(
+            config_dir=str(self.config_dir),
+            environment=self._environment,
+            module=self._module,
+        )
+
+        if self._environment_warning:
+            summary.warnings.append(self._environment_warning)
+
+        if not self.config_dir.exists():
+            summary.errors.append(f"Config directory not found: {self.config_dir}")
+            self._last_validation_summary = summary
+            return summary
+
+        defaults_file = self.config_dir / "defaults.yaml"
+        if not defaults_file.exists():
+            summary.warnings.append(f"Defaults file not found: {defaults_file}")
+
+        env_file = self.config_dir / "environments" / f"{self._environment}.yaml"
+        if not env_file.exists():
+            summary.warnings.append(
+                f"Environment file not found for '{self._environment}': {env_file}"
+            )
+
+        if self._module:
+            module_dir = self.config_dir / self._module
+            if not module_dir.exists():
+                summary.warnings.append(
+                    f"Module config directory not found: {module_dir}"
+                )
+
+        mappings_dir = self.config_dir / "mappings"
+        if mappings_dir.exists():
+            mappings = self._load_mappings()
+            if not isinstance(mappings, dict):
+                summary.errors.append(
+                    f"Mappings must load as a dictionary from {mappings_dir}"
+                )
+            elif any(value is None for value in mappings.values()):
+                summary.errors.append(
+                    f"Mappings in {mappings_dir} contain empty or malformed entries"
+                )
+
+        self._last_validation_summary = summary
+        return summary
 
     def set_validation_level(self, level: str) -> "ConfigManager":
         """Set the validation level

--- a/healthchain/execution.py
+++ b/healthchain/execution.py
@@ -1,0 +1,368 @@
+"""Execution declarations for inline and background-capable workflows."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import re
+
+from contextlib import contextmanager
+from contextvars import ContextVar, Token
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Awaitable, Callable, Iterator, Optional, Protocol, Union
+from uuid import uuid4
+
+
+class ExecutionMode(str, Enum):
+    """Supported execution modes."""
+
+    INLINE = "inline"
+    BACKGROUND = "background"
+
+
+class ExecutionCapability(str, Enum):
+    """Declares whether a workflow is inline-only or can be deferred."""
+
+    INLINE_ONLY = "inline-only"
+    ASYNC_CAPABLE = "async-capable"
+
+
+ExecutionModeLike = Union[ExecutionMode, str, None]
+
+
+def normalize_execution_mode(mode: ExecutionModeLike) -> Optional[ExecutionMode]:
+    """Normalize a caller-provided execution mode."""
+    if mode is None:
+        return None
+    if isinstance(mode, ExecutionMode):
+        return mode
+    return ExecutionMode(mode)
+
+
+@dataclass(frozen=True)
+class ExecutionProfile:
+    """Declares the supported execution modes for a workflow."""
+
+    capability: ExecutionCapability = ExecutionCapability.INLINE_ONLY
+    default_mode: ExecutionMode = ExecutionMode.INLINE
+    background_hint: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if (
+            self.default_mode == ExecutionMode.BACKGROUND
+            and self.capability != ExecutionCapability.ASYNC_CAPABLE
+        ):
+            raise ValueError(
+                "Background default_mode requires an async-capable execution profile."
+            )
+
+    @property
+    def supported_modes(self) -> tuple[ExecutionMode, ...]:
+        if self.capability == ExecutionCapability.ASYNC_CAPABLE:
+            return (ExecutionMode.INLINE, ExecutionMode.BACKGROUND)
+        return (ExecutionMode.INLINE,)
+
+    @property
+    def supports_background(self) -> bool:
+        return self.capability == ExecutionCapability.ASYNC_CAPABLE
+
+    def resolve_mode(self, mode: ExecutionModeLike = None) -> ExecutionMode:
+        """Validate and resolve a requested execution mode."""
+        resolved = normalize_execution_mode(mode) or self.default_mode
+        if resolved not in self.supported_modes:
+            raise ValueError(
+                f"Execution mode '{resolved.value}' is not supported by the "
+                f"'{self.capability.value}' execution profile."
+            )
+        return resolved
+
+    def as_metadata(self) -> dict[str, object]:
+        """Return JSON-safe metadata for reporting and inspection."""
+        metadata: dict[str, object] = {
+            "capability": self.capability.value,
+            "default_mode": self.default_mode.value,
+            "supported_modes": [mode.value for mode in self.supported_modes],
+        }
+        if self.background_hint:
+            metadata["background_hint"] = self.background_hint
+        return metadata
+
+    @classmethod
+    def inline_only(cls) -> "ExecutionProfile":
+        return cls()
+
+    @classmethod
+    def async_capable(
+        cls,
+        *,
+        default_mode: ExecutionMode = ExecutionMode.INLINE,
+        background_hint: Optional[str] = None,
+    ) -> "ExecutionProfile":
+        return cls(
+            capability=ExecutionCapability.ASYNC_CAPABLE,
+            default_mode=default_mode,
+            background_hint=background_hint,
+        )
+
+
+@dataclass(frozen=True)
+class ExecutionPlan:
+    """Resolved execution intent for a pipeline or gateway operation."""
+
+    scope: str
+    mode: ExecutionMode
+    profile: ExecutionProfile
+
+    def as_metadata(self) -> dict[str, object]:
+        metadata = {"scope": self.scope, "mode": self.mode.value}
+        metadata.update(self.profile.as_metadata())
+        return metadata
+
+
+class RuntimeScope(str, Enum):
+    """Runtime activity and error scope."""
+
+    REQUEST = "request"
+    PIPELINE = "pipeline"
+    INTEROP = "interop"
+    STARTUP = "startup"
+    INTERNAL = "internal"
+
+
+class RuntimeStatus(str, Enum):
+    """Lifecycle status for runtime events."""
+
+    STARTED = "started"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True)
+class RuntimeErrorSurface:
+    """Typed runtime error metadata for hooks and response mapping."""
+
+    phase: RuntimeScope
+    code: str
+    message: str
+    status_code: int = 500
+    retryable: bool = False
+    detail: Optional[Any] = None
+    correlation_id: Optional[str] = None
+
+    def as_metadata(self) -> dict[str, object]:
+        metadata: dict[str, object] = {
+            "phase": self.phase.value,
+            "code": self.code,
+            "message": self.message,
+            "status_code": self.status_code,
+            "retryable": self.retryable,
+        }
+        if self.detail is not None:
+            metadata["detail"] = self.detail
+        if self.correlation_id:
+            metadata["correlation_id"] = self.correlation_id
+        return metadata
+
+
+@dataclass(frozen=True)
+class RuntimeEvent:
+    """Structured runtime event delivered to pluggable hooks."""
+
+    name: str
+    activity: RuntimeScope
+    status: RuntimeStatus
+    scope: str
+    correlation_id: Optional[str]
+    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    details: dict[str, object] = field(default_factory=dict)
+    error: Optional[RuntimeErrorSurface] = None
+
+    def as_metadata(self) -> dict[str, object]:
+        metadata: dict[str, object] = {
+            "name": self.name,
+            "activity": self.activity.value,
+            "status": self.status.value,
+            "scope": self.scope,
+            "timestamp": self.timestamp.isoformat(),
+            "details": self.details,
+        }
+        if self.correlation_id:
+            metadata["correlation_id"] = self.correlation_id
+        if self.error is not None:
+            metadata["error"] = self.error.as_metadata()
+        return metadata
+
+
+class RuntimeHook(Protocol):
+    """Protocol for pluggable runtime sinks."""
+
+    def emit(self, event: RuntimeEvent) -> Optional[Awaitable[None]]: ...
+
+
+RuntimeHookLike = Union[
+    RuntimeHook, Callable[[RuntimeEvent], Optional[Awaitable[None]]]
+]
+
+
+class RuntimeHooks:
+    """Sync-friendly manager for pluggable runtime hooks."""
+
+    def __init__(self, hooks: Optional[list[RuntimeHookLike]] = None):
+        self._hooks: list[RuntimeHookLike] = list(hooks or [])
+
+    def register(self, hook: RuntimeHookLike) -> RuntimeHookLike:
+        self._hooks.append(hook)
+        return hook
+
+    def emit(self, event: RuntimeEvent) -> None:
+        for hook in list(self._hooks):
+            emit = getattr(hook, "emit", hook)
+            result = emit(event)
+            if inspect.isawaitable(result):
+                _consume_awaitable(result)
+
+
+_RUNTIME_CORRELATION_ID: ContextVar[Optional[str]] = ContextVar(
+    "healthchain_runtime_correlation_id",
+    default=None,
+)
+_RUNTIME_HOOKS: ContextVar[Optional[RuntimeHooks]] = ContextVar(
+    "healthchain_runtime_hooks",
+    default=None,
+)
+
+
+def generate_correlation_id() -> str:
+    return str(uuid4())
+
+
+def get_correlation_id() -> Optional[str]:
+    return _RUNTIME_CORRELATION_ID.get()
+
+
+def get_runtime_hooks() -> Optional[RuntimeHooks]:
+    return _RUNTIME_HOOKS.get()
+
+
+@contextmanager
+def runtime_context(
+    *,
+    correlation_id: Optional[str] = None,
+    hooks: Optional[RuntimeHooks] = None,
+) -> Iterator[None]:
+    correlation_token: Optional[Token[Optional[str]]] = None
+    hooks_token: Optional[Token[Optional[RuntimeHooks]]] = None
+    try:
+        if correlation_id is not None:
+            correlation_token = _RUNTIME_CORRELATION_ID.set(correlation_id)
+        if hooks is not None:
+            hooks_token = _RUNTIME_HOOKS.set(hooks)
+        yield
+    finally:
+        if hooks_token is not None:
+            _RUNTIME_HOOKS.reset(hooks_token)
+        if correlation_token is not None:
+            _RUNTIME_CORRELATION_ID.reset(correlation_token)
+
+
+def record_runtime_event(
+    *,
+    name: str,
+    activity: RuntimeScope,
+    status: RuntimeStatus,
+    scope: str,
+    details: Optional[dict[str, object]] = None,
+    error: Optional[RuntimeErrorSurface] = None,
+    correlation_id: Optional[str] = None,
+    hooks: Optional[RuntimeHooks] = None,
+) -> Optional[RuntimeEvent]:
+    resolved_hooks = hooks or get_runtime_hooks()
+    if resolved_hooks is None:
+        return None
+    event = RuntimeEvent(
+        name=name,
+        activity=activity,
+        status=status,
+        scope=scope,
+        correlation_id=correlation_id or get_correlation_id(),
+        details=details or {},
+        error=error,
+    )
+    resolved_hooks.emit(event)
+    return event
+
+
+def map_runtime_error(
+    exc: Exception,
+    *,
+    phase: RuntimeScope = RuntimeScope.INTERNAL,
+    correlation_id: Optional[str] = None,
+) -> RuntimeErrorSurface:
+    from fastapi import HTTPException
+    from fastapi.exceptions import RequestValidationError
+
+    resolved_correlation_id = correlation_id or get_correlation_id()
+    if isinstance(exc, RequestValidationError):
+        return RuntimeErrorSurface(
+            phase=RuntimeScope.REQUEST,
+            code="request.validation_error",
+            message="Request validation failed",
+            status_code=422,
+            detail={"errors": exc.errors(), "body": exc.body},
+            correlation_id=resolved_correlation_id,
+        )
+    if isinstance(exc, HTTPException):
+        return RuntimeErrorSurface(
+            phase=RuntimeScope.REQUEST,
+            code=f"request.http_{exc.status_code}",
+            message=str(exc.detail),
+            status_code=exc.status_code,
+            detail=exc.detail,
+            correlation_id=resolved_correlation_id,
+        )
+
+    status_code = _coerce_status_code(getattr(exc, "state", None)) or 500
+    upstream_code = getattr(exc, "code", exc.__class__.__name__)
+    detail = {"exception_type": exc.__class__.__name__}
+    if getattr(exc, "state", None) is not None:
+        detail["upstream_state"] = str(exc.state)
+    if getattr(exc, "code", None) is not None:
+        detail["upstream_code"] = str(exc.code)
+
+    return RuntimeErrorSurface(
+        phase=phase,
+        code=f"{phase.value}.{_slugify(upstream_code)}",
+        message=getattr(exc, "message", str(exc)),
+        status_code=status_code,
+        retryable=status_code >= 500,
+        detail=detail,
+        correlation_id=resolved_correlation_id,
+    )
+
+
+def _consume_awaitable(result: Awaitable[None]) -> None:
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(result)
+        finally:
+            loop.close()
+    else:
+        asyncio.create_task(result)
+
+
+def _coerce_status_code(value: object) -> Optional[int]:
+    try:
+        status_code = int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    return status_code if 100 <= status_code <= 599 else None
+
+
+def _slugify(value: object) -> str:
+    text = re.sub(r"[^a-z0-9]+", "_", str(value).lower()).strip("_")
+    return text or "error"

--- a/healthchain/gateway/api/app.py
+++ b/healthchain/gateway/api/app.py
@@ -7,6 +7,7 @@ healthcare-specific gateways, routes, middleware, and capabilities.
 
 import logging
 import re
+import sys
 
 from contextlib import asynccontextmanager
 from datetime import datetime
@@ -17,11 +18,41 @@ from fastapi.responses import JSONResponse
 
 from typing import Dict, Optional, Type, Union
 
+from healthchain.execution import (
+    RuntimeHooks,
+    RuntimeScope,
+    RuntimeStatus,
+    generate_correlation_id,
+    map_runtime_error,
+    record_runtime_event,
+    runtime_context,
+)
 from healthchain.gateway.base import BaseGateway, BaseProtocolHandler
 from healthchain.gateway.events.dispatcher import EventDispatcher
 from healthchain.gateway.api.dependencies import get_app
 
 logger = logging.getLogger(__name__)
+
+_CORRELATION_HEADER = "X-Correlation-ID"
+_ERROR_CODE_HEADER = "X-HealthChain-Error-Code"
+_ERROR_PHASE_HEADER = "X-HealthChain-Error-Phase"
+
+_ANSI_ESCAPE_RE = re.compile(r"\033\[[^m]*m")
+_BANNER_FALLBACK_TRANSLATION = str.maketrans(
+    {
+        "╭": "+",
+        "╮": "+",
+        "╰": "+",
+        "╯": "+",
+        "│": "|",
+        "─": "-",
+        "✓": "ok",
+        "✗": "x",
+        "█": "#",
+        "▄": "#",
+        "▀": "#",
+    }
+)
 
 # ── Half-block pixel font (4 wide × 3 tall, encodes 2 logical rows per char) ──
 _HB = {
@@ -60,11 +91,41 @@ def _gradient(text: str, t0: float, t1: float) -> str:
 
 
 def _vlen(s: str) -> int:
-    return len(re.sub(r"\033\[[^m]*m", "", s))
+    return len(_ANSI_ESCAPE_RE.sub("", s))
 
 
 def _pad(s: str, width: int) -> str:
     return s + " " * max(0, width - _vlen(s))
+
+
+def _plain_console_text(text: str, encoding: Optional[str] = None) -> str:
+    plain = _ANSI_ESCAPE_RE.sub("", text).translate(_BANNER_FALLBACK_TRANSLATION)
+    safe_encoding = encoding or "ascii"
+    try:
+        return plain.encode(safe_encoding, errors="backslashreplace").decode(
+            safe_encoding
+        )
+    except LookupError:
+        return plain.encode("ascii", errors="backslashreplace").decode("ascii")
+
+
+def _write_console_text(text: str) -> None:
+    stream = sys.stdout
+    if stream is None:
+        return
+
+    output = text
+    encoding = getattr(stream, "encoding", None)
+    if encoding:
+        try:
+            text.encode(encoding)
+        except (LookupError, UnicodeEncodeError):
+            output = _plain_console_text(text, encoding)
+
+    try:
+        stream.write(output)
+    except UnicodeEncodeError:
+        stream.write(_plain_console_text(text, encoding))
 
 
 def _val_bool(enabled: bool) -> str:
@@ -98,6 +159,18 @@ def _status_row(key: str, value: str) -> str:
     return f"\033[1m\033[38;2;0;255;135m{key}\033[0m  {value}"
 
 
+def _startup_validation_status(summary) -> str:
+    if summary is None:
+        return "\033[2mnot available\033[0m"
+    if summary.errors:
+        return f"\033[38;2;255;85;85mx {len(summary.errors)} error(s)\033[0m"
+    if summary.warnings:
+        return f"\033[38;2;255;200;50m! {len(summary.warnings)} warning(s)\033[0m"
+    if summary.status == "defaulted":
+        return "\033[38;2;255;200;50m! defaults\033[0m"
+    return "\033[38;2;0;255;135mok\033[0m"
+
+
 def _print_startup_banner(
     title: str,
     version: str,
@@ -106,6 +179,7 @@ def _print_startup_banner(
     docs_url: str,
     config=None,
     config_path: Optional[str] = None,
+    validation_summary=None,
 ) -> None:
     """Print pixel-wordmark banner with live status panel."""
     health_rows = _render_word("HEALTH")
@@ -155,6 +229,7 @@ def _print_startup_banner(
         _status_row("tls:        ", _val_bool(tls)),
         _status_row("hipaa:      ", _val_bool(hipaa)),
         _status_row("eval:       ", _val_eval(eval_enabled, eval_provider)),
+        _status_row("validation: ", _startup_validation_status(validation_summary)),
         "",
         _status_row("config:     ", f"\033[1m{config_path or '(none)'}\033[0m"),
         _status_row("docs:       ", f"\033[1mhttp://localhost:{port}{docs_url}\033[0m"),
@@ -190,13 +265,12 @@ def _print_startup_banner(
     border = "\033[38;2;99;102;241m"  # indigo
     rst = "\033[0m"
 
-    print()
-    print(f"{border}╭{'─' * (inner_w + 2)}╮{rst}")
+    lines = ["", f"{border}╭{'─' * (inner_w + 2)}╮{rst}"]
     for logo_line, s in zip(logo_lines, status):
         padding = " " * (max_status_w - _vlen(s))
-        print(f"{border}│{rst} {logo_line}   {s}{padding} {border}│{rst}")
-    print(f"{border}╰{'─' * (inner_w + 2)}╯{rst}")
-    print()
+        lines.append(f"{border}│{rst} {logo_line}   {s}{padding} {border}│{rst}")
+    lines.extend([f"{border}╰{'─' * (inner_w + 2)}╯{rst}", ""])
+    _write_console_text("\n".join(lines) + "\n")
 
 
 class HealthChainAPI(FastAPI):
@@ -240,6 +314,7 @@ class HealthChainAPI(FastAPI):
         enable_cors: bool = True,
         enable_events: bool = True,
         event_dispatcher: Optional[EventDispatcher] = None,
+        runtime_hooks: Optional[RuntimeHooks] = None,
         **kwargs,
     ):
         """
@@ -252,6 +327,7 @@ class HealthChainAPI(FastAPI):
             enable_cors: Enable CORS middleware
             enable_events: Enable event dispatching
             event_dispatcher: Optional custom event dispatcher
+            runtime_hooks: Optional structured runtime hook sinks
             **kwargs: Additional FastAPI configuration
         """
         super().__init__(
@@ -267,6 +343,8 @@ class HealthChainAPI(FastAPI):
         self.services = {}
         self.gateway_endpoints = {}
         self.service_endpoints = {}
+        self.runtime_hooks = runtime_hooks or RuntimeHooks()
+        self.app_config, self.startup_validation_summary = self._load_startup_config()
 
         # Event system setup
         self.enable_events = enable_events
@@ -278,17 +356,21 @@ class HealthChainAPI(FastAPI):
             else:
                 from healthchain.gateway.events.dispatcher import EventDispatcher
 
-                self.event_dispatcher = EventDispatcher()
+                self.event_dispatcher = EventDispatcher(
+                    runtime_hooks=self.runtime_hooks
+                )
+
+            if hasattr(self.event_dispatcher, "set_runtime_hooks"):
+                self.event_dispatcher.set_runtime_hooks(self.runtime_hooks)
 
             # Initialize the event dispatcher
             self.event_dispatcher.init_app(self)
 
         # Setup middleware
         if enable_cors:
-            from healthchain.config.appconfig import AppConfig
-
-            _config = AppConfig.load()
-            origins = _config.security.allowed_origins if _config else ["*"]
+            origins = (
+                self.app_config.security.allowed_origins if self.app_config else ["*"]
+            )
             self.add_middleware(
                 CORSMiddleware,
                 allow_origins=origins,
@@ -299,6 +381,7 @@ class HealthChainAPI(FastAPI):
 
         # Add global exception handler
         self.add_exception_handler(Exception, self._exception_handler)
+        self.middleware("http")(self._request_runtime_middleware)
 
         # Add default routes
         self._add_default_routes()
@@ -324,6 +407,60 @@ class HealthChainAPI(FastAPI):
             The application's event dispatcher, or None if events are disabled
         """
         return self.event_dispatcher
+
+    def get_startup_validation_summary(self) -> Optional[dict]:
+        if self.startup_validation_summary is None:
+            return None
+        return self.startup_validation_summary.model_dump()
+
+    async def _request_runtime_middleware(self, request: Request, call_next):
+        correlation_id = (
+            request.headers.get(_CORRELATION_HEADER) or generate_correlation_id()
+        )
+        request.state.correlation_id = correlation_id
+        request.state.runtime_error = None
+
+        with runtime_context(correlation_id=correlation_id, hooks=self.runtime_hooks):
+            record_runtime_event(
+                name="request.started",
+                activity=RuntimeScope.REQUEST,
+                status=RuntimeStatus.STARTED,
+                scope=request.url.path,
+                details={"method": request.method},
+                hooks=self.runtime_hooks,
+                correlation_id=correlation_id,
+            )
+            try:
+                response = await call_next(request)
+            except Exception as exc:
+                response = await self._exception_handler(request, exc)
+            response.headers.setdefault(_CORRELATION_HEADER, correlation_id)
+
+            runtime_error = getattr(request.state, "runtime_error", None)
+            if runtime_error is not None:
+                response.headers.setdefault(_ERROR_CODE_HEADER, runtime_error.code)
+                response.headers.setdefault(
+                    _ERROR_PHASE_HEADER, runtime_error.phase.value
+                )
+
+            record_runtime_event(
+                name="request.completed",
+                activity=RuntimeScope.REQUEST,
+                status=RuntimeStatus.COMPLETED,
+                scope=request.url.path,
+                details={
+                    "method": request.method,
+                    "status_code": response.status_code,
+                },
+                hooks=self.runtime_hooks,
+                correlation_id=correlation_id,
+            )
+            return response
+
+    def _load_startup_config(self):
+        from healthchain.config.appconfig import AppConfig
+
+        return AppConfig.load_with_summary(strict=True)
 
     def _register_component(
         self,
@@ -574,47 +711,77 @@ class HealthChainAPI(FastAPI):
         self, request: Request, exc: Exception
     ) -> JSONResponse:
         """Unified exception handler for all types of exceptions."""
+        correlation_id = (
+            getattr(request.state, "correlation_id", None) or generate_correlation_id()
+        )
+        headers: Dict[str, str] = {_CORRELATION_HEADER: correlation_id}
+
         if isinstance(exc, RequestValidationError):
-            return JSONResponse(
-                status_code=422,
-                content={"detail": exc.errors(), "body": exc.body},
-            )
+            runtime_error = map_runtime_error(exc, correlation_id=correlation_id)
+            content = {"detail": exc.errors(), "body": exc.body}
         elif isinstance(exc, HTTPException):
-            return JSONResponse(
-                status_code=exc.status_code,
-                content={"detail": exc.detail},
-                headers=exc.headers,
-            )
+            runtime_error = map_runtime_error(exc, correlation_id=correlation_id)
+            content = {"detail": exc.detail}
+            headers.update(exc.headers or {})
         else:
-            logger.exception("Unhandled exception", exc_info=exc)
-            return JSONResponse(
-                status_code=500,
-                content={"detail": "Internal server error"},
+            runtime_error = map_runtime_error(
+                exc,
+                phase=RuntimeScope.INTERNAL,
+                correlation_id=correlation_id,
             )
+            logger.exception("Unhandled exception", exc_info=exc)
+            content = {"detail": "Internal server error"}
+
+        headers[_CORRELATION_HEADER] = correlation_id
+        headers[_ERROR_CODE_HEADER] = runtime_error.code
+        headers[_ERROR_PHASE_HEADER] = runtime_error.phase.value
+        request.state.runtime_error = runtime_error
+
+        record_runtime_event(
+            name="request.failed",
+            activity=RuntimeScope.REQUEST,
+            status=RuntimeStatus.FAILED,
+            scope=request.url.path,
+            details={"method": request.method},
+            error=runtime_error,
+            hooks=self.runtime_hooks,
+            correlation_id=correlation_id,
+        )
+        return JSONResponse(
+            status_code=runtime_error.status_code,
+            content=content,
+            headers=headers,
+        )
 
     async def _startup(self) -> None:
         """Display startup information and initialize components."""
-        from healthchain.config.appconfig import AppConfig
+        with runtime_context(
+            correlation_id=generate_correlation_id(),
+            hooks=self.runtime_hooks,
+        ):
+            _print_startup_banner(
+                title=self.app_config.name if self.app_config else self.title,
+                version=self.app_config.version if self.app_config else self.version,
+                gateways=self.gateways,
+                services=self.services,
+                docs_url=self.docs_url or "http://localhost:8000/docs",
+                config=self.app_config,
+                config_path=(
+                    self.startup_validation_summary.config_path
+                    if self.startup_validation_summary
+                    else None
+                ),
+                validation_summary=self.startup_validation_summary,
+            )
 
-        config = AppConfig.load()
-        _print_startup_banner(
-            title=config.name if config else self.title,
-            version=config.version if config else self.version,
-            gateways=self.gateways,
-            services=self.services,
-            docs_url=self.docs_url or "http://localhost:8000/docs",
-            config=config,
-            config_path="./healthchain.yaml" if config else None,
-        )
-
-        # Initialize components
-        for name, component in {**self.gateways, **self.services}.items():
-            if hasattr(component, "startup") and callable(component.startup):
-                try:
-                    await component.startup()
-                    logger.debug(f"Initialized: {name}")
-                except Exception as e:
-                    logger.warning(f"Failed to initialize {name}: {e}")
+            # Initialize components
+            for name, component in {**self.gateways, **self.services}.items():
+                if hasattr(component, "startup") and callable(component.startup):
+                    try:
+                        await component.startup()
+                        logger.debug(f"Initialized: {name}")
+                    except Exception as e:
+                        logger.warning(f"Failed to initialize {name}: {e}")
 
     async def _shutdown(self) -> None:
         """Handle graceful shutdown."""

--- a/healthchain/gateway/base.py
+++ b/healthchain/gateway/base.py
@@ -13,6 +13,18 @@ from typing import Any, Callable, Dict, List, TypeVar, Generic, Optional, Union
 from pydantic import BaseModel
 from fastapi import APIRouter
 
+from healthchain.execution import (
+    ExecutionModeLike,
+    ExecutionPlan,
+    ExecutionProfile,
+    RuntimeScope,
+    RuntimeStatus,
+    generate_correlation_id,
+    get_correlation_id,
+    map_runtime_error,
+    record_runtime_event,
+    runtime_context,
+)
 from healthchain.gateway.api.protocols import EventDispatcherProtocol
 
 
@@ -170,6 +182,7 @@ class BaseProtocolHandler(ABC, Generic[T, R]):
             **options: Additional configuration options
         """
         self._handlers = {}
+        self._execution_profiles: Dict[str, ExecutionProfile] = {}
         self.options = options
         self.config = config or GatewayConfig()
         self.use_events = use_events
@@ -179,19 +192,63 @@ class BaseProtocolHandler(ABC, Generic[T, R]):
         )
         self.events = EventCapability()
 
-    def register_handler(self, operation: str, handler: Callable) -> P:
+    def register_handler(
+        self,
+        operation: str,
+        handler: Callable,
+        *,
+        execution_profile: Optional[ExecutionProfile] = None,
+    ) -> P:
         """
         Register a handler function for a specific operation.
 
         Args:
             operation: The operation name or identifier
             handler: Function that will handle the operation
+            execution_profile: Declares whether the operation is inline-only or
+                can later be executed in background mode
 
         Returns:
             Self, to allow for method chaining
         """
         self._handlers[operation] = handler
+        self._execution_profiles[operation] = (
+            execution_profile or ExecutionProfile.inline_only()
+        )
         return self
+
+    def set_execution_profile(
+        self, operation: str, execution_profile: ExecutionProfile
+    ) -> P:
+        """Update the execution declaration for a registered operation."""
+        if operation not in self._handlers:
+            raise ValueError(f"Operation '{operation}' is not registered.")
+        self._execution_profiles[operation] = execution_profile
+        return self
+
+    def get_execution_profile(self, operation: str) -> ExecutionProfile:
+        """Return the execution declaration for an operation."""
+        return self._execution_profiles.get(operation, ExecutionProfile.inline_only())
+
+    def plan_execution(
+        self, operation: str, execution_mode: ExecutionModeLike = None
+    ) -> ExecutionPlan:
+        """Resolve execution intent for a registered operation."""
+        if operation not in self._handlers:
+            raise ValueError(f"Unsupported operation: {operation}")
+        profile = self.get_execution_profile(operation)
+        return ExecutionPlan(
+            scope=operation,
+            mode=profile.resolve_mode(execution_mode),
+            profile=profile,
+        )
+
+    def get_execution_capabilities(self) -> Dict[str, Dict[str, object]]:
+        """Return execution metadata for all registered operations."""
+        return {
+            operation: self.get_execution_profile(operation).as_metadata()
+            for operation in self._handlers
+        }
 
     async def handle(self, operation: str, **params) -> Union[R, Dict[str, Any]]:
         """
@@ -205,27 +262,106 @@ class BaseProtocolHandler(ABC, Generic[T, R]):
         Returns:
             The response object or error dictionary
         """
+        correlation_id = get_correlation_id() or generate_correlation_id()
+        scope = f"{self.__class__.__name__}.{operation}"
         if operation in self._handlers:
             handler = self._handlers[operation]
-            try:
-                # Support both async and non-async handlers
-                if asyncio.iscoroutinefunction(handler):
-                    result = await handler(**params)
-                else:
-                    result = handler(**params)
-                return self._process_result(result)
-            except Exception as e:
-                logger.error(
-                    f"Error in handler for operation {operation}: {str(e)}",
-                    exc_info=True,
+            plan = self.plan_execution(operation)
+            with runtime_context(correlation_id=correlation_id):
+                record_runtime_event(
+                    name="interop.operation.started",
+                    activity=RuntimeScope.INTEROP,
+                    status=RuntimeStatus.STARTED,
+                    scope=scope,
+                    details={"execution": plan.as_metadata()},
                 )
-                return self._handle_error(str(e))
+                try:
+                    # Support both async and non-async handlers
+                    if asyncio.iscoroutinefunction(handler):
+                        result = await handler(**params)
+                    else:
+                        result = handler(**params)
+                    processed = self._process_result(result)
+                except Exception as e:
+                    logger.error(
+                        f"Error in handler for operation {operation}: {str(e)}",
+                        exc_info=True,
+                    )
+                    runtime_error = map_runtime_error(
+                        e,
+                        phase=RuntimeScope.INTEROP,
+                        correlation_id=correlation_id,
+                    )
+                    record_runtime_event(
+                        name="interop.operation.failed",
+                        activity=RuntimeScope.INTEROP,
+                        status=RuntimeStatus.FAILED,
+                        scope=scope,
+                        details={"execution": plan.as_metadata()},
+                        error=runtime_error,
+                    )
+                    return self._handle_error(str(e))
+
+                record_runtime_event(
+                    name="interop.operation.completed",
+                    activity=RuntimeScope.INTEROP,
+                    status=RuntimeStatus.COMPLETED,
+                    scope=scope,
+                    details={"execution": plan.as_metadata()},
+                )
+                return processed
 
         # Fall back to default handler
-        if asyncio.iscoroutinefunction(self._default_handler):
-            return await self._default_handler(operation, **params)
-        else:
-            return self._default_handler(operation, **params)
+        with runtime_context(correlation_id=correlation_id):
+            record_runtime_event(
+                name="interop.operation.started",
+                activity=RuntimeScope.INTEROP,
+                status=RuntimeStatus.STARTED,
+                scope=scope,
+                details={"execution": ExecutionProfile.inline_only().as_metadata()},
+            )
+            try:
+                if asyncio.iscoroutinefunction(self._default_handler):
+                    result = await self._default_handler(operation, **params)
+                else:
+                    result = self._default_handler(operation, **params)
+            except Exception as e:
+                runtime_error = map_runtime_error(
+                    e,
+                    phase=RuntimeScope.INTEROP,
+                    correlation_id=correlation_id,
+                )
+                record_runtime_event(
+                    name="interop.operation.failed",
+                    activity=RuntimeScope.INTEROP,
+                    status=RuntimeStatus.FAILED,
+                    scope=scope,
+                    details={"execution": ExecutionProfile.inline_only().as_metadata()},
+                    error=runtime_error,
+                )
+                raise
+            if isinstance(result, dict) and "error" in result:
+                record_runtime_event(
+                    name="interop.operation.failed",
+                    activity=RuntimeScope.INTEROP,
+                    status=RuntimeStatus.FAILED,
+                    scope=scope,
+                    details={"execution": ExecutionProfile.inline_only().as_metadata()},
+                    error=map_runtime_error(
+                        ValueError(result["error"]),
+                        phase=RuntimeScope.INTEROP,
+                        correlation_id=correlation_id,
+                    ),
+                )
+            else:
+                record_runtime_event(
+                    name="interop.operation.completed",
+                    activity=RuntimeScope.INTEROP,
+                    status=RuntimeStatus.COMPLETED,
+                    scope=scope,
+                    details={"execution": ExecutionProfile.inline_only().as_metadata()},
+                )
+            return result
 
     def _process_result(self, result: Any) -> R:
         """

--- a/healthchain/gateway/events/dispatcher.py
+++ b/healthchain/gateway/events/dispatcher.py
@@ -9,6 +9,16 @@ from fastapi_events.dispatcher import dispatch
 from fastapi_events.handlers.local import local_handler
 from fastapi_events.middleware import EventHandlerASGIMiddleware
 
+from healthchain.execution import (
+    RuntimeHooks,
+    RuntimeScope,
+    RuntimeStatus,
+    generate_correlation_id,
+    get_correlation_id,
+    map_runtime_error,
+    record_runtime_event,
+    runtime_context,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -62,10 +72,11 @@ class EventDispatcher:
         ```
     """
 
-    def __init__(self):
+    def __init__(self, runtime_hooks: Optional[RuntimeHooks] = None):
         """Initialize the event dispatcher."""
         self.handlers_registry = {}
         self.app = None
+        self.runtime_hooks = runtime_hooks
         # Generate a unique middleware ID to support dispatching outside of requests
         self.middleware_id = id(self)
 
@@ -111,6 +122,13 @@ class EventDispatcher:
         # Return the local_handler.register decorator with "*" pattern
         return local_handler.register(event_name="*")
 
+    def set_runtime_hooks(
+        self, runtime_hooks: Optional[RuntimeHooks]
+    ) -> "EventDispatcher":
+        """Attach pluggable runtime hooks for structured interop events."""
+        self.runtime_hooks = runtime_hooks
+        return self
+
     async def publish(self, event: EHREvent, middleware_id: Optional[int] = None):
         """Publish an event to all registered handlers.
 
@@ -119,20 +137,63 @@ class EventDispatcher:
             middleware_id (Optional[int]): Custom middleware ID, defaults to self.middleware_id
                 if not provided. This is needed for dispatching outside of request contexts.
         """
-        # Convert event to the format expected by fastapi-events
+        correlation_id = get_correlation_id() or generate_correlation_id()
+        event.metadata.setdefault("correlation_id", correlation_id)
         event_name = event.event_type.value
         event_data = event.model_dump(exclude_none=True)
 
         # Use the provided middleware_id or fall back to the class's middleware_id
         mid = middleware_id or self.middleware_id
 
-        # Dispatch the event with the middleware_id
-        # Note: dispatch may return None instead of an awaitable, so handle that case
-        logger.debug(f"Dispatching event: {event_name}")
+        details = {
+            "event_type": event_name,
+            "source_system": event.source_system,
+            "middleware_id": mid,
+            "payload_keys": sorted(event.payload.keys()),
+            "metadata_keys": sorted(event.metadata.keys()),
+        }
 
-        result = dispatch(event_name, event_data, middleware_id=mid)
-        if result is not None:
-            await result
+        with runtime_context(correlation_id=correlation_id, hooks=self.runtime_hooks):
+            record_runtime_event(
+                name="interop.event.started",
+                activity=RuntimeScope.INTEROP,
+                status=RuntimeStatus.STARTED,
+                scope=event_name,
+                details=details,
+                hooks=self.runtime_hooks,
+            )
+
+            # Dispatch the event with the middleware_id
+            # Note: dispatch may return None instead of an awaitable, so handle that case
+            logger.debug(f"Dispatching event: {event_name}")
+            try:
+                result = dispatch(event_name, event_data, middleware_id=mid)
+                if result is not None:
+                    await result
+            except Exception as exc:
+                record_runtime_event(
+                    name="interop.event.failed",
+                    activity=RuntimeScope.INTEROP,
+                    status=RuntimeStatus.FAILED,
+                    scope=event_name,
+                    details=details,
+                    error=map_runtime_error(
+                        exc,
+                        phase=RuntimeScope.INTEROP,
+                        correlation_id=correlation_id,
+                    ),
+                    hooks=self.runtime_hooks,
+                )
+                raise
+
+            record_runtime_event(
+                name="interop.event.completed",
+                activity=RuntimeScope.INTEROP,
+                status=RuntimeStatus.COMPLETED,
+                scope=event_name,
+                details=details,
+                hooks=self.runtime_hooks,
+            )
 
     def emit(self, event: EHREvent, middleware_id: Optional[int] = None):
         """Publish an event from synchronous code by handling async context automatically.

--- a/healthchain/io/containers/document.py
+++ b/healthchain/io/containers/document.py
@@ -1,7 +1,7 @@
 import logging
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, Iterator, List, Optional, Union
+from typing import Any, Dict, ItemsView, Iterator, List, Optional, Union
 from uuid import uuid4
 
 from spacy.tokens import Doc as SpacyDoc
@@ -208,6 +208,100 @@ class ModelOutputs:
                 )
 
         return generated_text
+
+
+@dataclass
+class DocumentCompartment:
+    """
+    Lightweight key/value compartment for explicit Document-side state.
+
+    This keeps auxiliary mutation out of Document's top-level namespace while
+    preserving a small, ergonomic API.
+    """
+
+    _values: Dict[str, Any] = field(default_factory=dict, repr=False)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self._values.get(key, default)
+
+    def set(self, key: str, value: Any) -> Any:
+        self._values[key] = value
+        return value
+
+    def update(self, values: Optional[Dict[str, Any]] = None, **kwargs: Any) -> None:
+        if values:
+            self._values.update(values)
+        if kwargs:
+            self._values.update(kwargs)
+
+    def pop(self, key: str, default: Any = None) -> Any:
+        return self._values.pop(key, default)
+
+    def clear(self) -> None:
+        self._values.clear()
+
+    def as_dict(self) -> Dict[str, Any]:
+        return dict(self._values)
+
+    def items(self) -> ItemsView[str, Any]:
+        return self._values.items()
+
+    def __contains__(self, key: str) -> bool:
+        return key in self._values
+
+    def __getitem__(self, key: str) -> Any:
+        return self._values[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self._values[key] = value
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._values)
+
+    def __len__(self) -> int:
+        return len(self._values)
+
+    def __bool__(self) -> bool:
+        return bool(self._values)
+
+
+@dataclass
+class DocumentMetadata(DocumentCompartment):
+    """
+    Stable descriptive context for a document.
+
+    Keep identifiers, labels, and other durable descriptors here instead of in
+    domain compartments.
+    """
+
+
+@dataclass
+class DocumentArtifacts(DocumentCompartment):
+    """
+    Durable derived outputs that do not fit a typed domain compartment.
+
+    Store auxiliary payloads here when they may need inspection or persistence.
+    """
+
+    def record(self, name: str, value: Any, version: Optional[str] = None) -> Any:
+        if version is None:
+            return self.set(name, value)
+        return self.set(name, {"value": value, "version": version})
+
+
+@dataclass
+class ExecutionState(DocumentCompartment):
+    """
+    Ephemeral runtime state for the active adapter or pipeline flow.
+
+    This compartment is for in-memory scratch data only and should be cleared at
+    execution boundaries instead of persisted as business data.
+    """
+
+    def mark_stage(self, stage: str, **kwargs: Any) -> None:
+        self.set("stage", stage)
+        if kwargs:
+            self.update(kwargs)
 
 
 @dataclass
@@ -701,12 +795,27 @@ class Document(BaseDocument):
         - Stores and manipulates clinical FHIR data via the .fhir property (access to bundles, problem lists, meds, allergies, etc.).
         - Encapsulates CDS Hooks-style decision support cards and suggested actions via the .cds property.
         - Stores outputs from external ML/LLM models: HuggingFace, LangChain, etc.
+        - Exposes explicit contract compartments for durable metadata, auxiliary artifacts,
+          and ephemeral execution state.
+
+    Mutation guidance:
+        - Keep typed domain payloads inside .nlp, .fhir, .cds, and .models.
+        - Keep stable descriptors such as source identifiers or tags inside .metadata.
+        - Keep durable derived outputs that do not belong in typed compartments inside
+          .artifacts.
+        - Keep request-local or stage-local scratch data inside .execution.
+        - Keep raw transport envelopes at the adapter boundary instead of persisting
+          them on the Document whenever possible.
 
     Attributes:
+        input: Explicit alias for the original input boundary (.data)
         nlp (NlpAnnotations): NLP output (tokens, entities, embeddings, spaCy doc)
         fhir (FhirData): FHIR resources and context (problem list, medication, allergy, etc.)
         cds (CdsAnnotations): Clinical decision support (cards and actions)
         models (ModelOutputs): Results from ML/LLM models (HuggingFace, LangChain, etc.)
+        metadata (DocumentMetadata): Stable descriptive context for the document.
+        artifacts (DocumentArtifacts): Durable derived outputs and compatibility shims.
+        execution (ExecutionState): Ephemeral runtime state for active pipeline work.
         text (str): The text content of the document (if available).
         data: The original input supplied (raw text, Bundle, resource, or list of resources)
 
@@ -728,6 +837,13 @@ class Document(BaseDocument):
     _fhir: FhirData = field(default_factory=FhirData)
     _cds: CdsAnnotations = field(default_factory=CdsAnnotations)
     _models: ModelOutputs = field(default_factory=ModelOutputs)
+    _metadata: DocumentMetadata = field(default_factory=DocumentMetadata, repr=False)
+    _artifacts: DocumentArtifacts = field(default_factory=DocumentArtifacts, repr=False)
+    _execution: ExecutionState = field(default_factory=ExecutionState, repr=False)
+
+    @property
+    def input(self) -> Any:
+        return self.data
 
     @property
     def nlp(self) -> NlpAnnotations:
@@ -744,6 +860,30 @@ class Document(BaseDocument):
     @property
     def models(self) -> ModelOutputs:
         return self._models
+
+    @property
+    def metadata(self) -> DocumentMetadata:
+        return self._metadata
+
+    @property
+    def artifacts(self) -> DocumentArtifacts:
+        return self._artifacts
+
+    @property
+    def execution(self) -> ExecutionState:
+        return self._execution
+
+    def set_metadata(self, key: str, value: Any) -> Any:
+        return self._metadata.set(key, value)
+
+    def add_artifact(self, name: str, value: Any, version: Optional[str] = None) -> Any:
+        return self._artifacts.record(name, value, version=version)
+
+    def set_execution(self, key: str, value: Any) -> Any:
+        return self._execution.set(key, value)
+
+    def clear_execution(self) -> None:
+        self._execution.clear()
 
     def __post_init__(self):
         """

--- a/healthchain/pipeline/base.py
+++ b/healthchain/pipeline/base.py
@@ -2,23 +2,35 @@ import logging
 from abc import ABC, abstractmethod
 from inspect import signature
 from pathlib import Path
+from dataclasses import dataclass, field
+from enum import Enum
+from functools import reduce
 from typing import (
     Any,
     Callable,
-    Optional,
-    Type,
-    Union,
+    Dict,
+    Generic,
     List,
     Literal,
-    Dict,
+    Optional,
+    Type,
     TypeVar,
-    Generic,
+    Union,
 )
-from functools import reduce
 from pydantic import BaseModel
-from dataclasses import dataclass, field
-from enum import Enum
 
+from healthchain.execution import (
+    ExecutionModeLike,
+    ExecutionPlan,
+    ExecutionProfile,
+    RuntimeScope,
+    RuntimeStatus,
+    generate_correlation_id,
+    get_correlation_id,
+    map_runtime_error,
+    record_runtime_event,
+    runtime_context,
+)
 from healthchain.io.containers import DataContainer
 from healthchain.pipeline.components.base import BaseComponent
 
@@ -91,6 +103,15 @@ class BasePipeline(Generic[T], ABC):
         _output_template (Optional[str]): Template string for formatting pipeline outputs
         _output_template_path (Optional[Path]): Path to template file for formatting pipeline outputs
 
+    Mutation guidance:
+        - Treat typed document compartments (.nlp, .fhir, .cds, .models) as the
+          canonical home for domain outputs.
+        - Put durable auxiliary outputs in document.artifacts when they do not fit
+          a typed compartment.
+        - Put stable cross-cutting descriptors in document.metadata.
+        - Put ephemeral stage-local scratch data in document.execution and clear it
+          at execution boundaries instead of persisting it as business data.
+
     Example:
         >>> class MyPipeline(BasePipeline[Document]):
         ...     def configure_pipeline(self, config: ModelConfig) -> None:
@@ -102,12 +123,13 @@ class BasePipeline(Generic[T], ABC):
         >>> result = pipeline(document)  # Document → Document
     """
 
-    def __init__(self):
+    def __init__(self, execution_profile: Optional[ExecutionProfile] = None):
         self._components: List[PipelineNode[T]] = []
         self._stages: Dict[str, List[Callable]] = {}
         self._built_pipeline: Optional[Callable] = None
         self._output_template: Optional[str] = None
         self._output_template_path: Optional[Path] = None
+        self._execution_profile = execution_profile or ExecutionProfile.inline_only()
 
     def __repr__(self) -> str:
         components_repr = ", ".join(
@@ -140,6 +162,7 @@ class BasePipeline(Generic[T], ABC):
         task: Optional[str] = "text-generation",
         template: Optional[str] = None,
         template_path: Optional[Union[str, Path]] = None,
+        execution_profile: Optional[ExecutionProfile] = None,
         **kwargs: Any,
     ) -> "BasePipeline":
         """
@@ -191,6 +214,8 @@ class BasePipeline(Generic[T], ABC):
             task = pipeline.task
 
         instance = cls()
+        if execution_profile is not None:
+            instance.configure_execution(execution_profile)
         instance._configure_output_templates(template, template_path)
 
         config = ModelConfig(
@@ -213,6 +238,7 @@ class BasePipeline(Generic[T], ABC):
         task: Optional[str] = "text-generation",
         template: Optional[str] = None,
         template_path: Optional[Union[str, Path]] = None,
+        execution_profile: Optional[ExecutionProfile] = None,
         **kwargs: Any,
     ) -> "BasePipeline":
         """
@@ -257,6 +283,8 @@ class BasePipeline(Generic[T], ABC):
             ... )
         """
         pipeline = cls()
+        if execution_profile is not None:
+            pipeline.configure_execution(execution_profile)
         pipeline._configure_output_templates(template, template_path)
 
         config = ModelConfig(
@@ -278,6 +306,7 @@ class BasePipeline(Generic[T], ABC):
         task: Optional[str] = None,
         template: Optional[str] = None,
         template_path: Optional[Union[str, Path]] = None,
+        execution_profile: Optional[ExecutionProfile] = None,
         **kwargs: Any,
     ) -> "BasePipeline":
         """Load pipeline from a local model path.
@@ -321,6 +350,8 @@ class BasePipeline(Generic[T], ABC):
             ... )
         """
         pipeline = cls()
+        if execution_profile is not None:
+            pipeline.configure_execution(execution_profile)
         pipeline._configure_output_templates(template, template_path)
 
         path = Path(path)
@@ -406,6 +437,26 @@ class BasePipeline(Generic[T], ABC):
                                                     and values are lists of callable components.
         """
         self._stages = new_stages
+
+    @property
+    def execution_profile(self) -> ExecutionProfile:
+        """Return the declared execution profile for this pipeline."""
+        return self._execution_profile
+
+    def configure_execution(
+        self, execution_profile: ExecutionProfile
+    ) -> "BasePipeline":
+        """Declare how this pipeline may execute without changing its default behavior."""
+        self._execution_profile = execution_profile
+        return self
+
+    def plan_execution(self, mode: ExecutionModeLike = None) -> ExecutionPlan:
+        """Resolve execution intent for runtime callers and future background runners."""
+        return ExecutionPlan(
+            scope=self.__class__.__name__,
+            mode=self._execution_profile.resolve_mode(mode),
+            profile=self._execution_profile,
+        )
 
     def add_node(
         self,
@@ -687,9 +738,54 @@ class BasePipeline(Generic[T], ABC):
             )
 
     def __call__(self, data: Union[T, DataContainer[T]]) -> DataContainer[T]:
-        if self._built_pipeline is None:
-            self._built_pipeline = self.build()
-        return self._built_pipeline(data)
+        correlation_id = get_correlation_id() or generate_correlation_id()
+        plan = self.plan_execution()
+        scope = self.__class__.__name__
+        with runtime_context(correlation_id=correlation_id):
+            record_runtime_event(
+                name="pipeline.execution.started",
+                activity=RuntimeScope.PIPELINE,
+                status=RuntimeStatus.STARTED,
+                scope=scope,
+                details={
+                    "execution": plan.as_metadata(),
+                    "component_count": len(self._components),
+                },
+            )
+            try:
+                if self._built_pipeline is None:
+                    self._built_pipeline = self.build()
+                result = self._built_pipeline(data)
+            except Exception as exc:
+                runtime_error = map_runtime_error(
+                    exc,
+                    phase=RuntimeScope.PIPELINE,
+                    correlation_id=correlation_id,
+                )
+                record_runtime_event(
+                    name="pipeline.execution.failed",
+                    activity=RuntimeScope.PIPELINE,
+                    status=RuntimeStatus.FAILED,
+                    scope=scope,
+                    details={
+                        "execution": plan.as_metadata(),
+                        "component_count": len(self._components),
+                    },
+                    error=runtime_error,
+                )
+                raise
+
+            record_runtime_event(
+                name="pipeline.execution.completed",
+                activity=RuntimeScope.PIPELINE,
+                status=RuntimeStatus.COMPLETED,
+                scope=scope,
+                details={
+                    "execution": plan.as_metadata(),
+                    "component_count": len(self._components),
+                },
+            )
+            return result
 
     def build(self) -> Callable:
         """

--- a/tests/gateway/test_api_app.py
+++ b/tests/gateway/test_api_app.py
@@ -1,5 +1,8 @@
 """Tests for the HealthChainAPI class."""
 
+import io
+import sys
+
 import pytest
 from unittest.mock import AsyncMock
 from fastapi import Depends, HTTPException
@@ -92,6 +95,27 @@ def test_lifespan_startup_shutdown():
         assert client.get("/health").status_code == 200
 
     assert gateway.shutdown_called
+
+
+def test_lifespan_startup_degrades_for_cp1252_stdout(monkeypatch):
+    """Startup should stay live when stdout cannot encode banner glyphs."""
+    buffer = io.BytesIO()
+    stdout = io.TextIOWrapper(buffer, encoding="cp1252", errors="strict")
+    monkeypatch.setattr(sys, "stdout", stdout)
+
+    app = HealthChainAPI(title="Encoding Safe API")
+
+    with TestClient(app) as client:
+        assert client.get("/health").status_code == 200
+
+    stdout.flush()
+    output = buffer.getvalue().decode("cp1252")
+
+    assert "Encoding Safe API" in output
+    assert "validation:" in output
+    assert "docs:" in output
+    assert "╭" not in output
+    assert "█" not in output
 
 
 def test_dependency_injection(app, mock_dispatcher, mock_gateway):


### PR DESCRIPTION
## Summary
- harden `Document` compartments and execution state surfaces
- add typed startup/config validation summaries and clearer runtime contracts
- introduce a runtime execution seam, correlation-aware hooks, and safer gateway startup behavior
- include focused gateway coverage for the Windows startup-banner encoding path

## Why
The current runtime shell mixes document state, startup validation, and request execution concerns too loosely. This patch makes those contracts more explicit so request-time work stays stable now, while leaving a clean seam for later background-capable execution without forcing a queue platform.

## Impact
- `Document`, config loading, and gateway/runtime coordination become more explicit and typed
- startup validation and runtime error handling are easier to inspect and extend
- Windows console startup no longer crashes on limited encodings
- inline execution remains the default behavior

## Validation
- backend and QA runs on the task wave reported passing targeted verification for the touched runtime surfaces
- focused gateway checks covered the cp1252 startup-banner path
