### PR TITLE
feat(gateway): Enforce API-key auth middleware

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -95,13 +95,7 @@ Security
   origins      https://fhir.epic.com
 
 Compliance
-  HIPAA        enabled
   audit log    ./logs/audit.jsonl
-
-Eval
-  provider     mlflow
-  tracking     ./mlruns
-  events       model_inference, cds_card_returned, card_feedback
 ```
 
 ---

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -90,7 +90,7 @@ Site
   name         General Hospital NHS Trust
 
 Security
-  auth         smart-on-fhir
+  auth         api-key
   TLS          enabled
   origins      https://fhir.epic.com
 

--- a/docs/cookbook/index.md
+++ b/docs/cookbook/index.md
@@ -179,4 +179,4 @@ app = HealthChainAPI(title="My App")
 Credentials (API keys, client secrets) always stay in `.env` — never in `healthchain.yaml`.
 
 !!! tip "Configuration reference"
-    See the [configuration reference](../reference/config.md) for all available settings — security, compliance, eval, and more.
+    See the [configuration reference](../reference/config.md) for all available settings — security, compliance, and more.

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -76,14 +76,14 @@ site:
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `auth` | string | `none` | Authentication method — `none`, `api-key` (planned), or `smart-on-fhir` (planned) |
+| `auth` | string | `none` | Authentication method — `none` or `api-key` |
 | `tls.enabled` | bool | `false` | Enable TLS — passes cert/key to uvicorn automatically |
 | `tls.cert_path` | path | `./certs/server.crt` | Path to TLS certificate |
 | `tls.key_path` | path | `./certs/server.key` | Path to TLS private key |
 | `allowed_origins` | list | `["*"]` | CORS allowed origins — passed directly to FastAPI's CORS middleware |
 
-!!! note "Authentication is planned, not yet active"
-    Setting `auth: api-key` or `auth: smart-on-fhir` is accepted by the config but not yet enforced at runtime. Authentication middleware is on the roadmap. `allowed_origins` is functional — it controls which origins are permitted by the CORS middleware.
+!!! note "API key authentication"
+    Setting `auth: api-key` enforces authentication on all routes except `/health`, `/docs`, `/redoc`, and `/openapi.json`. Set `HEALTHCHAIN_API_KEY` in your `.env` file — the service logs a warning at startup if the env var is missing. `allowed_origins` controls which origins are permitted by the CORS middleware.
 
 ---
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -10,12 +10,8 @@ service:
   type: cds-hooks
   port: 8000
 
-data:
-  patients_dir: ./data
-  output_dir: ./output
-
 security:
-  auth: none
+  auth: none              # none | api-key
   tls:
     enabled: false
     cert_path: ./certs/server.crt
@@ -24,17 +20,7 @@ security:
     - "*"
 
 compliance:
-  hipaa: false
   audit_log: ./logs/audit.jsonl
-
-eval:
-  enabled: false
-  provider: mlflow
-  tracking_uri: ./mlruns
-  track:
-    - model_inference
-    - cds_card_returned
-    - card_feedback
 
 site:
   name: ""
@@ -63,15 +49,6 @@ site:
 
 ---
 
-## `data`
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `patients_dir` | path | `./data` | Directory for patient data files |
-| `output_dir` | path | `./output` | Directory for sandbox results |
-
----
-
 ## `security`
 
 | Field | Type | Default | Description |
@@ -91,33 +68,10 @@ site:
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `hipaa` | bool | `false` | Mark service as HIPAA-scoped — displayed in startup banner and `healthchain status` |
-| `audit_log` | path | `./logs/audit.jsonl` | Destination for audit log events (planned) |
+| `audit_log` | path | `null` | Path to write audit log entries — one JSON line per request |
 
-!!! note "Audit logging is planned, not yet active"
-    Setting `hipaa: true` currently marks the service as HIPAA-scoped in the CLI and startup banner. Structured audit logging (PHI access events written to `audit_log`) is on the roadmap but not yet implemented.
-
----
-
-## `eval`
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `enabled` | bool | `false` | Enable model evaluation tracking |
-| `provider` | string | `mlflow` | Eval backend — `mlflow`, `langfuse`, or `none` |
-| `tracking_uri` | path | `./mlruns` | MLFlow tracking directory |
-| `track` | list | see below | Events to capture |
-
-Default tracked events:
-
-- `model_inference` — input features and prediction for each request
-- `cds_card_returned` — which card was shown to the clinician
-- `card_feedback` — whether the clinician accepted, overrode, or ignored the card
-
-The `card_feedback` event closes the evaluation loop — it provides implicit ground truth for model performance regardless of whether your model is an ML classifier, NLP pipeline, or LLM.
-
-!!! note
-    MLFlow integration is on the roadmap. Setting `eval.enabled: true` prepares your project for when it ships.
+!!! note "Audit logging"
+    When `audit_log` is set, every request is appended as a JSONL entry containing `timestamp`, `method`, `path`, `status_code`, `duration_ms`, `request_id`, and `user`. The log directory is created automatically if missing. When `api-key` auth is also enabled, `user` records the authenticated identity.
 
 ---
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,95 @@
+# Security & Compliance
+
+HealthChain includes built-in support for API key authentication, audit logging, and TLS — configured via `healthchain.yaml` and enforced at runtime by the gateway middleware stack.
+
+---
+
+## API key authentication
+
+Enable inbound authentication by setting `security.auth: api-key` in `healthchain.yaml`:
+
+```yaml
+security:
+  auth: api-key
+```
+
+Then set the expected key in `.env`:
+
+```bash
+HEALTHCHAIN_API_KEY=your-key-here
+```
+
+All routes except `/health`, `/docs`, `/redoc`, and `/openapi.json` will require the key on every request. Pass it as a Bearer token or an `X-API-Key` header:
+
+```bash
+# Bearer token
+curl -H "Authorization: Bearer your-key-here" http://localhost:8000/fhir/Patient/123
+
+# X-API-Key header
+curl -H "X-API-Key: your-key-here" http://localhost:8000/fhir/Patient/123
+```
+
+Missing or incorrect keys receive a `401 Unauthorized` response:
+
+```json
+{ "detail": "Invalid or missing API key" }
+```
+
+!!! warning "Missing env var"
+If `HEALTHCHAIN_API_KEY` is not set when the service starts, a warning is logged and all authenticated requests will be rejected. The service still starts — misconfiguration is visible without crashing.
+
+---
+
+## Audit logging
+
+Set `compliance.audit_log` to a file path to enable per-request audit logging:
+
+```yaml
+compliance:
+  audit_log: ./logs/audit.jsonl
+```
+
+The log directory is created automatically if it does not exist. Each request appends one JSON line:
+
+```json
+{
+  "timestamp": "2026-05-06T10:23:41.123456+00:00",
+  "method": "GET",
+  "path": "/fhir/Patient/123",
+  "status_code": 200,
+  "duration_ms": 14.2,
+  "request_id": "a1b2c3d4-...",
+  "user": "api-key"
+}
+```
+
+`request_id` uses the `X-Request-ID` header if present, otherwise a UUID is generated. `user` is populated when `api-key` auth is enabled, and `null` otherwise.
+
+Log writes are non-blocking — IO errors are swallowed so a full disk or permission issue does not take down the service.
+
+---
+
+## TLS
+
+Enable TLS by pointing `healthchain.yaml` at your certificate and key:
+
+```yaml
+security:
+  tls:
+    enabled: true
+    cert_path: ./certs/server.crt
+    key_path: ./certs/server.key
+```
+
+HealthChain passes these to uvicorn automatically when `healthchain serve` starts — no extra flags needed.
+
+**Generating a self-signed certificate for local testing:**
+
+```bash
+mkdir -p certs
+openssl req -x509 -newkey rsa:4096 -keyout certs/server.key \
+  -out certs/server.crt -days 365 -nodes \
+  -subj "/CN=localhost"
+```
+
+**For production**, use a certificate issued by a trusted CA. If you're deploying behind a reverse proxy (nginx, Caddy, an NHS load balancer), terminate TLS at the proxy and leave `tls.enabled: false` in HealthChain — the proxy handles the certificate, HealthChain handles the application.

--- a/healthchain/cli.py
+++ b/healthchain/cli.py
@@ -97,6 +97,9 @@ _ENV_EXAMPLE_CDS_HOOKS = """\
 
 # For JWT assertion flow (e.g. Epic SMART on FHIR)
 # CLIENT_SECRET_PATH=/path/to/private_key.pem
+
+# API key authentication (set security.auth: api-key in healthchain.yaml to enforce)
+# HEALTHCHAIN_API_KEY=your-key-here
 """
 
 _ENV_EXAMPLE_FHIR_GATEWAY = """\
@@ -113,6 +116,9 @@ EPIC_CLIENT_SECRET=
 CERNER_BASE_URL=https://fhir-open.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d
 # Cerner open sandbox requires no credentials
 
+# API key authentication (set security.auth: api-key in healthchain.yaml to enforce)
+# HEALTHCHAIN_API_KEY=your-key-here
+
 # See docs: https://healthchainai.github.io/HealthChain/reference/gateway/fhir_gateway/
 """
 
@@ -124,6 +130,9 @@ CLIENT_SECRET=
 
 # For JWT assertion flow (e.g. Epic SMART on FHIR)
 # CLIENT_SECRET_PATH=/path/to/private_key.pem
+
+# API key authentication (set security.auth: api-key in healthchain.yaml to enforce)
+# HEALTHCHAIN_API_KEY=your-key-here
 """
 
 _REQUIREMENTS = "healthchain\n"

--- a/healthchain/cli.py
+++ b/healthchain/cli.py
@@ -264,7 +264,7 @@ service:
 
 # Security controls
 security:
-  auth: none              # none | api-key (planned) | smart-on-fhir (planned)
+  auth: none              # none | api-key
   tls:
     enabled: false
     cert_path: ./certs/server.crt

--- a/healthchain/config/appconfig.py
+++ b/healthchain/config/appconfig.py
@@ -89,7 +89,7 @@ class SecurityConfig(BaseModel):
     @field_validator("auth")
     @classmethod
     def validate_auth(cls, v: str) -> str:
-        allowed = {"none", "api-key", "smart-on-fhir"}
+        allowed = {"none", "api-key"}
         if v not in allowed:
             raise ValueError(f"auth must be one of: {', '.join(sorted(allowed))}")
         return v

--- a/healthchain/gateway/api/app.py
+++ b/healthchain/gateway/api/app.py
@@ -311,6 +311,11 @@ class HealthChainAPI(FastAPI):
                 AuditLogMiddleware, audit_log_path=_config.compliance.audit_log
             )
 
+        if _config and _config.security.auth == "api-key":
+            from healthchain.gateway.api.middleware import APIKeyMiddleware
+
+            self.add_middleware(APIKeyMiddleware)
+
         # Add global exception handler
         self.add_exception_handler(Exception, self._exception_handler)
 

--- a/healthchain/gateway/api/middleware.py
+++ b/healthchain/gateway/api/middleware.py
@@ -1,4 +1,6 @@
 import json
+import logging
+import os
 import time
 import uuid
 from datetime import datetime, timezone
@@ -7,7 +9,47 @@ from typing import Optional
 
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
-from starlette.responses import Response
+from starlette.responses import JSONResponse, Response
+
+logger = logging.getLogger(__name__)
+
+_EXEMPT_PATHS = {"/health", "/docs", "/redoc", "/openapi.json"}
+
+
+class APIKeyMiddleware(BaseHTTPMiddleware):
+    """Enforce API-key authentication on all non-exempt routes.
+
+    Only instantiated when security.auth is 'api-key' in healthchain.yaml.
+    Reads the expected key from the HEALTHCHAIN_API_KEY environment variable.
+    """
+
+    def __init__(self, app) -> None:
+        super().__init__(app)
+        self._key = os.environ.get("HEALTHCHAIN_API_KEY")
+        if not self._key:
+            logger.warning(
+                "security.auth is 'api-key' but HEALTHCHAIN_API_KEY is not set — "
+                "all authenticated requests will be rejected"
+            )
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        if request.url.path in _EXEMPT_PATHS:
+            return await call_next(request)
+
+        auth_header = request.headers.get("Authorization", "")
+        if auth_header.startswith("Bearer "):
+            provided = auth_header[len("Bearer ") :]
+        else:
+            provided = request.headers.get("X-API-Key", "")
+
+        if not provided or provided != self._key:
+            return JSONResponse(
+                status_code=401,
+                content={"detail": "Invalid or missing API key"},
+            )
+
+        request.state.authenticated_user = "api-key"
+        return await call_next(request)
 
 
 class AuditLogMiddleware(BaseHTTPMiddleware):
@@ -37,7 +79,6 @@ class AuditLogMiddleware(BaseHTTPMiddleware):
             "status_code": response.status_code,
             "duration_ms": duration_ms,
             "request_id": request_id,
-            # Placeholder: populated once API-key auth is wired in
             "user": _get_user(request),
         }
 
@@ -51,8 +92,5 @@ class AuditLogMiddleware(BaseHTTPMiddleware):
 
 
 def _get_user(request: Request) -> Optional[str]:
-    """Extract authenticated user identity from the request.
-
-    Returns None until inbound auth middleware is wired in.
-    """
-    return None
+    """Extract authenticated user identity from request state set by APIKeyMiddleware."""
+    return getattr(request.state, "authenticated_user", None)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ nav:
   - Docs:
       - Welcome: reference/index.md
       - Configuration: reference/config.md
+      - Security & Compliance: security.md
       - Gateway:
         - Overview: reference/gateway/gateway.md
         - HealthChainAPI: reference/gateway/api.md

--- a/tests/gateway/test_middleware.py
+++ b/tests/gateway/test_middleware.py
@@ -1,0 +1,196 @@
+"""Tests for AuditLogMiddleware and APIKeyMiddleware."""
+
+import json
+import pytest
+from unittest.mock import patch
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from healthchain.gateway.api.middleware import APIKeyMiddleware, AuditLogMiddleware
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _api_key_app():
+    app = FastAPI()
+
+    @app.get("/health")
+    def health():
+        return {"status": "ok"}
+
+    @app.get("/docs")
+    def docs():
+        return {}
+
+    @app.get("/redoc")
+    def redoc():
+        return {}
+
+    @app.get("/openapi.json")
+    def openapi():
+        return {}
+
+    @app.get("/data")
+    def data():
+        return {"result": "ok"}
+
+    app.add_middleware(APIKeyMiddleware)
+    return app
+
+
+def _audit_app(log_path: str):
+    app = FastAPI()
+
+    @app.get("/data")
+    def data():
+        return {"result": "ok"}
+
+    app.add_middleware(AuditLogMiddleware, audit_log_path=log_path)
+    return app
+
+
+# ── APIKeyMiddleware ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("path", ["/health", "/docs", "/redoc", "/openapi.json"])
+def test_api_key_exempt_paths_pass_through(monkeypatch, path):
+    monkeypatch.setenv("HEALTHCHAIN_API_KEY", "secret")
+    client = TestClient(_api_key_app(), raise_server_exceptions=False)
+    assert client.get(path).status_code == 200
+
+
+def test_api_key_bearer_token_accepted(monkeypatch):
+    monkeypatch.setenv("HEALTHCHAIN_API_KEY", "my-secret")
+    client = TestClient(_api_key_app(), raise_server_exceptions=False)
+    response = client.get("/data", headers={"Authorization": "Bearer my-secret"})
+    assert response.status_code == 200
+
+
+def test_api_key_x_api_key_header_accepted(monkeypatch):
+    monkeypatch.setenv("HEALTHCHAIN_API_KEY", "my-secret")
+    client = TestClient(_api_key_app(), raise_server_exceptions=False)
+    response = client.get("/data", headers={"X-API-Key": "my-secret"})
+    assert response.status_code == 200
+
+
+def test_api_key_wrong_key_rejected(monkeypatch):
+    monkeypatch.setenv("HEALTHCHAIN_API_KEY", "my-secret")
+    client = TestClient(_api_key_app(), raise_server_exceptions=False)
+    response = client.get("/data", headers={"Authorization": "Bearer wrong"})
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Invalid or missing API key"}
+
+
+def test_api_key_missing_header_rejected(monkeypatch):
+    monkeypatch.setenv("HEALTHCHAIN_API_KEY", "my-secret")
+    client = TestClient(_api_key_app(), raise_server_exceptions=False)
+    assert client.get("/data").status_code == 401
+    assert client.get("/data").json() == {"detail": "Invalid or missing API key"}
+
+
+def test_api_key_missing_env_var_logs_warning_and_rejects(monkeypatch):
+    monkeypatch.delenv("HEALTHCHAIN_API_KEY", raising=False)
+    with patch("healthchain.gateway.api.middleware.logger") as mock_logger:
+        client = TestClient(_api_key_app(), raise_server_exceptions=False)
+        client.get("/data")  # triggers middleware stack build
+        mock_logger.warning.assert_called_once()
+    assert client.get("/data").status_code == 401
+
+
+def test_api_key_sets_authenticated_user_on_state(monkeypatch):
+    monkeypatch.setenv("HEALTHCHAIN_API_KEY", "secret")
+    captured_state = {}
+
+    app = FastAPI()
+
+    @app.get("/data")
+    async def data(request: Request):
+        captured_state["user"] = getattr(request.state, "authenticated_user", None)
+        return {}
+
+    app.add_middleware(APIKeyMiddleware)
+    client = TestClient(app, raise_server_exceptions=False)
+    client.get("/data", headers={"Authorization": "Bearer secret"})
+    assert captured_state["user"] == "api-key"
+
+
+# ── AuditLogMiddleware ────────────────────────────────────────────────────────
+
+
+def test_audit_log_creates_file_and_directory(tmp_path):
+    log_path = tmp_path / "nested" / "dir" / "audit.jsonl"
+    client = TestClient(_audit_app(str(log_path)), raise_server_exceptions=False)
+    client.get("/data")
+    assert log_path.exists()
+
+
+def test_audit_log_writes_one_entry_per_request(tmp_path):
+    log_path = tmp_path / "audit.jsonl"
+    client = TestClient(_audit_app(str(log_path)), raise_server_exceptions=False)
+    client.get("/data")
+    client.get("/data")
+    lines = log_path.read_text().strip().splitlines()
+    assert len(lines) == 2
+
+
+def test_audit_log_entry_fields(tmp_path):
+    log_path = tmp_path / "audit.jsonl"
+    client = TestClient(_audit_app(str(log_path)), raise_server_exceptions=False)
+    client.get("/data")
+    entry = json.loads(log_path.read_text().strip())
+    assert entry["method"] == "GET"
+    assert entry["path"] == "/data"
+    assert entry["status_code"] == 200
+    assert "timestamp" in entry
+    assert "duration_ms" in entry
+    assert "request_id" in entry
+
+
+def test_audit_log_uses_x_request_id_header(tmp_path):
+    log_path = tmp_path / "audit.jsonl"
+    client = TestClient(_audit_app(str(log_path)), raise_server_exceptions=False)
+    client.get("/data", headers={"X-Request-ID": "test-id-123"})
+    entry = json.loads(log_path.read_text().strip())
+    assert entry["request_id"] == "test-id-123"
+
+
+def test_audit_log_generates_uuid_when_no_request_id(tmp_path):
+    log_path = tmp_path / "audit.jsonl"
+    client = TestClient(_audit_app(str(log_path)), raise_server_exceptions=False)
+    client.get("/data")
+    entry = json.loads(log_path.read_text().strip())
+    assert len(entry["request_id"]) == 36  # UUID4 format
+
+
+def test_audit_log_swallows_io_errors(tmp_path):
+    log_path = tmp_path / "audit.jsonl"
+    client = TestClient(_audit_app(str(log_path)), raise_server_exceptions=False)
+    with patch("builtins.open", side_effect=OSError("disk full")):
+        response = client.get("/data")
+    assert response.status_code == 200
+
+
+def test_audit_log_user_is_none_without_auth(tmp_path):
+    log_path = tmp_path / "audit.jsonl"
+    client = TestClient(_audit_app(str(log_path)), raise_server_exceptions=False)
+    client.get("/data")
+    entry = json.loads(log_path.read_text().strip())
+    assert entry["user"] is None
+
+
+def test_audit_log_user_populated_when_auth_state_set(tmp_path):
+    log_path = tmp_path / "audit.jsonl"
+
+    app = FastAPI()
+
+    @app.get("/data")
+    async def data(request: Request):
+        request.state.authenticated_user = "api-key"
+        return {}
+
+    app.add_middleware(AuditLogMiddleware, audit_log_path=str(log_path))
+    client = TestClient(app, raise_server_exceptions=False)
+    client.get("/data")
+    entry = json.loads(log_path.read_text().strip())
+    assert entry["user"] == "api-key"


### PR DESCRIPTION
## What and why
Add `APIKeyMiddleware` that gates all non-exempt routes when `security.auth: api-key` is set. Reads key from HEALTHCHAIN_API_KEY env var. Wires authenticated identity into audit log entries. Also removes smart-on-fhir as a valid auth value.