### PR TITLE
feat(fhir): validation spine — validate_resource, load_bundle, ValidationReport

### DIFF
--- a/healthchain/fhir/__init__.py
+++ b/healthchain/fhir/__init__.py
@@ -38,6 +38,14 @@ from healthchain.fhir.readers import (
     read_content_attachment,
 )
 
+from healthchain.fhir.validation import (
+    FHIRValidationError,
+    ValidationIssue,
+    ValidationReport,
+    load_bundle,
+    validate_resource,
+)
+
 from healthchain.fhir.bundlehelpers import (
     create_bundle,
     add_resource,
@@ -95,6 +103,12 @@ __all__ = [
     "convert_prefetch_to_fhir_objects",
     "prefetch_to_bundle",
     "read_content_attachment",
+    # Validation
+    "FHIRValidationError",
+    "ValidationIssue",
+    "ValidationReport",
+    "load_bundle",
+    "validate_resource",
     # Bundle operations
     "create_bundle",
     "add_resource",

--- a/healthchain/fhir/readers.py
+++ b/healthchain/fhir/readers.py
@@ -53,21 +53,47 @@ def _fix_timezone_naive_datetimes(data: Any) -> Any:
 
 
 def create_resource_from_dict(
-    resource_dict: Dict, resource_type: str
+    resource_dict: Dict, resource_type: str, raise_on_error: bool = False
 ) -> Optional[Resource]:
     """Create a FHIR resource instance from a dictionary
 
     Args:
         resource_dict: Dictionary representation of the resource
         resource_type: Type of FHIR resource to create
+        raise_on_error: If True, raise FHIRValidationError with a full
+            ValidationReport instead of returning None on failure
 
     Returns:
         Optional[Resource]: FHIR resource instance or None if creation failed
+
+    Raises:
+        FHIRValidationError: If raise_on_error is True and validation fails
     """
     try:
         resource_class = get_fhir_resource(resource_type)
         return resource_class(**resource_dict)
     except Exception as e:
+        if raise_on_error:
+            from healthchain.fhir.validation import (
+                FHIRValidationError,
+                ValidationIssue,
+                ValidationReport,
+                validate_resource,
+            )
+
+            report = validate_resource(resource_dict, resource_type=resource_type)
+            if report.valid:
+                # The constructor failed for a reason validation didn't reproduce
+                report = ValidationReport(
+                    valid=False,
+                    resource_type=resource_type,
+                    issues=[
+                        ValidationIssue(
+                            severity="fatal", code="exception", diagnostics=str(e)
+                        )
+                    ],
+                )
+            raise FHIRValidationError(report) from e
         logger.error(f"Failed to create FHIR resource: {str(e)}")
         return None
 

--- a/healthchain/fhir/validation.py
+++ b/healthchain/fhir/validation.py
@@ -1,0 +1,459 @@
+"""FHIR resource validation.
+
+This module provides an explicit validation surface for FHIR resources:
+a report-returning ``validate_resource`` suitable for agent tool loops,
+a raising ``load_bundle`` for loading bundles from files or dicts, and
+the ``ValidationReport``/``FHIRValidationError`` types they share.
+
+What IS checked:
+- Structure: field types, required fields, and unknown fields, as enforced
+  by the underlying ``fhir.resources`` Pydantic models.
+- Required bindings on primitive ``code`` fields: values are checked against
+  the value set shipped with the model metadata (e.g. ``MedicationStatement.status``).
+
+What is NOT checked:
+- Bindings on CodeableConcept/Coding fields (no ValueSet expansion is bundled).
+- FHIRPath invariants/constraints (e.g. "co-33: only one onset[x]").
+- Profile conformance (e.g. US Core, UK Core).
+- Reference integrity (whether referenced resources exist).
+
+For full conformance validation, use a FHIR server's ``$validate`` operation
+against the relevant profiles.
+"""
+
+import json
+import logging
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+from pydantic import BaseModel, Field, ValidationError
+from fhir.resources.resource import Resource
+
+from healthchain.fhir.version import (
+    FHIRVersion,
+    get_default_version,
+    get_fhir_resource,
+    get_resource_version,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Maps Pydantic error types to OperationOutcome issue type codes
+# https://www.hl7.org/fhir/valueset-issue-type.html
+_PYDANTIC_ERROR_TO_ISSUE_CODE = {
+    "missing": "required",
+    "extra_forbidden": "structure",
+}
+
+
+class ValidationIssue(BaseModel):
+    """A single validation issue, mirroring FHIR OperationOutcome.issue fields.
+
+    https://www.hl7.org/fhir/operationoutcome.html
+    """
+
+    severity: str = Field(
+        description="Issue severity: fatal | error | warning | information"
+    )
+    code: str = Field(
+        description="OperationOutcome issue type code, e.g. structure, required, "
+        "value, code-invalid, not-supported"
+    )
+    diagnostics: str = Field(description="Human-readable description of the issue")
+    expression: Optional[str] = Field(
+        default=None,
+        description="Path to the offending element, e.g. 'Condition.onsetDateTime'",
+    )
+
+
+class ValidationReport(BaseModel):
+    """Result of validating a FHIR resource.
+
+    JSON-serializable via ``model_dump()`` so it can be returned directly
+    from agent tools. Convert to a FHIR OperationOutcome resource with
+    ``to_operation_outcome()``.
+    """
+
+    valid: bool = Field(description="True if no error or fatal issues were found")
+    resource_type: Optional[str] = Field(
+        default=None, description="The FHIR resource type that was validated"
+    )
+    fhir_version: Optional[str] = Field(
+        default=None, description="The FHIR version validated against, e.g. 'R4B'"
+    )
+    issues: List[ValidationIssue] = Field(default_factory=list)
+
+    def to_operation_outcome(self) -> Resource:
+        """Convert the report to a FHIR OperationOutcome resource.
+
+        Returns:
+            An OperationOutcome of the report's FHIR version, with one issue
+            per validation issue (or a single 'informational' issue if valid).
+        """
+        outcome_class = get_fhir_resource("OperationOutcome", self.fhir_version)
+        issues: List[Dict[str, Any]] = [
+            {
+                "severity": issue.severity,
+                "code": issue.code,
+                "diagnostics": issue.diagnostics,
+                **({"expression": [issue.expression]} if issue.expression else {}),
+            }
+            for issue in self.issues
+        ]
+        if not issues:
+            issues = [
+                {
+                    "severity": "information",
+                    "code": "informational",
+                    "diagnostics": "Validation successful",
+                }
+            ]
+        return outcome_class(issue=issues)
+
+
+class FHIRValidationError(Exception):
+    """Raised when FHIR validation fails. Carries the full ValidationReport."""
+
+    def __init__(self, report: ValidationReport, message: Optional[str] = None):
+        self.report = report
+        if message is None:
+            summary = "; ".join(
+                f"{issue.expression or issue.code}: {issue.diagnostics}"
+                for issue in report.issues[:3]
+            )
+            count = len(report.issues)
+            message = (
+                f"Validation failed for {report.resource_type or 'resource'} "
+                f"with {count} issue{'s' if count != 1 else ''}: {summary}"
+            )
+            if count > 3:
+                message += f" (and {count - 3} more)"
+        super().__init__(message)
+
+
+def _format_expression(resource_type: str, loc: tuple) -> str:
+    """Format a Pydantic error location as a FHIRPath-style expression.
+
+    Example: ("entry", 0, "resource", "subject") -> "Bundle.entry[0].resource.subject"
+    """
+    expression = resource_type
+    for part in loc:
+        if isinstance(part, int):
+            expression += f"[{part}]"
+        else:
+            expression += f".{part}"
+    return expression
+
+
+def _structural_issues(
+    error: ValidationError, resource_type: str
+) -> List[ValidationIssue]:
+    """Convert a Pydantic ValidationError into validation issues."""
+    return [
+        ValidationIssue(
+            severity="error",
+            code=_PYDANTIC_ERROR_TO_ISSUE_CODE.get(err["type"], "value"),
+            diagnostics=err["msg"],
+            expression=_format_expression(resource_type, err["loc"]),
+        )
+        for err in error.errors()
+    ]
+
+
+def _check_bindings(model: BaseModel, path: str) -> List[ValidationIssue]:
+    """Recursively check primitive code fields against their required bindings.
+
+    Walks model fields looking for ``enum_values`` in each field's
+    ``json_schema_extra`` metadata (shipped by fhir.resources for required
+    bindings on code-typed fields) and reports values outside the value set.
+    """
+    issues: List[ValidationIssue] = []
+    for name, field in type(model).model_fields.items():
+        value = getattr(model, name, None)
+        if value is None:
+            continue
+
+        alias = field.alias or name
+        extra = field.json_schema_extra
+        enum_values = extra.get("enum_values") if isinstance(extra, dict) else None
+
+        if enum_values:
+            values = value if isinstance(value, list) else [value]
+            for i, item in enumerate(values):
+                if isinstance(item, str) and item not in enum_values:
+                    expression = f"{path}.{alias}"
+                    if isinstance(value, list):
+                        expression += f"[{i}]"
+                    issues.append(
+                        ValidationIssue(
+                            severity="error",
+                            code="code-invalid",
+                            diagnostics=(
+                                f"Value '{item}' is not in the required value set. "
+                                f"Allowed values: {', '.join(enum_values)}"
+                            ),
+                            expression=expression,
+                        )
+                    )
+        elif isinstance(value, BaseModel):
+            issues.extend(_check_bindings(value, f"{path}.{alias}"))
+        elif isinstance(value, list):
+            for i, item in enumerate(value):
+                if isinstance(item, BaseModel):
+                    issues.extend(_check_bindings(item, f"{path}.{alias}[{i}]"))
+    return issues
+
+
+def _class_version(resource_class: type) -> str:
+    """Detect the FHIR version of a resource class from its module path."""
+    module = resource_class.__module__
+    if ".R4B." in module:
+        return FHIRVersion.R4B.value
+    elif ".STU3." in module:
+        return FHIRVersion.STU3.value
+    return FHIRVersion.R5.value
+
+
+def validate_resource(
+    resource: Union[Dict[str, Any], Resource],
+    resource_type: Optional[str] = None,
+    version: Optional[Union[FHIRVersion, str]] = None,
+) -> ValidationReport:
+    """Validate a FHIR resource and return a report. Never raises.
+
+    Runs structural validation (types, required fields, unknown fields) and
+    checks primitive code fields against their required bindings. Binding
+    issues are only reported once structural validation passes. See the
+    module docstring for exactly what is and is not checked.
+
+    Args:
+        resource: A dict representation or an instantiated FHIR resource
+        resource_type: Resource type name (e.g. "Condition"). Optional if the
+            dict has a "resourceType" key or the input is already a resource
+        version: FHIR version to validate against (default: session default).
+            Ignored for instantiated resources, which carry their own version
+
+    Returns:
+        ValidationReport: ``valid`` is True when no error/fatal issues exist
+
+    Example:
+        >>> report = validate_resource({"resourceType": "Condition"})
+        >>> report.valid
+        False
+        >>> report.issues[0].expression
+        'Condition.subject'
+    """
+    if isinstance(resource, dict):
+        resolved_type = resource_type or resource.get("resourceType")
+        if not resolved_type:
+            return ValidationReport(
+                valid=False,
+                fhir_version=None,
+                issues=[
+                    ValidationIssue(
+                        severity="fatal",
+                        code="structure",
+                        diagnostics=(
+                            "Cannot determine resource type: no 'resourceType' key "
+                            "in the dict and no resource_type argument provided"
+                        ),
+                    )
+                ],
+            )
+
+        try:
+            resource_class = get_fhir_resource(resolved_type, version)
+        except ValueError as e:
+            requested = version if version is not None else get_default_version()
+            return ValidationReport(
+                valid=False,
+                resource_type=resolved_type,
+                fhir_version=requested.value
+                if isinstance(requested, FHIRVersion)
+                else str(requested).upper(),
+                issues=[
+                    ValidationIssue(
+                        severity="fatal", code="not-supported", diagnostics=str(e)
+                    )
+                ],
+            )
+
+        fhir_version = _class_version(resource_class)
+        try:
+            instance = resource_class.model_validate(resource)
+        except ValidationError as e:
+            return ValidationReport(
+                valid=False,
+                resource_type=resolved_type,
+                fhir_version=fhir_version,
+                issues=_structural_issues(e, resolved_type),
+            )
+    else:
+        resolved_type = resource.__class__.__name__
+        detected = get_resource_version(resource)
+        fhir_version = detected.value if detected else None
+        try:
+            # Re-validate to catch invalid post-construction mutations
+            resource.__class__.model_validate(resource.model_dump(exclude_none=True))
+        except ValidationError as e:
+            return ValidationReport(
+                valid=False,
+                resource_type=resolved_type,
+                fhir_version=fhir_version,
+                issues=_structural_issues(e, resolved_type),
+            )
+        instance = resource
+
+    issues = _check_bindings(instance, resolved_type)
+    valid = not any(issue.severity in ("error", "fatal") for issue in issues)
+    return ValidationReport(
+        valid=valid,
+        resource_type=resolved_type,
+        fhir_version=fhir_version,
+        issues=issues,
+    )
+
+
+def load_bundle(
+    source: Union[str, Path, Dict[str, Any]],
+    version: Optional[Union[FHIRVersion, str]] = None,
+) -> Resource:
+    """Load and validate a FHIR Bundle, raising on any validation error.
+
+    Validates the bundle structure and every entry resource, aggregating all
+    issues into a single report rather than failing on the first error.
+    Issue expressions locate the offending entry, e.g.
+    ``Bundle.entry[2].resource.subject``. See the module docstring for
+    exactly what is and is not checked.
+
+    Args:
+        source: A file path, a JSON string, or a dict representation of a Bundle
+        version: FHIR version to validate against (default: session default)
+
+    Returns:
+        Bundle: The validated Bundle instance
+
+    Raises:
+        FHIRValidationError: If parsing or validation fails; carries the
+            full ValidationReport in ``.report``
+        FileNotFoundError: If a file path is given but does not exist
+
+    Example:
+        >>> bundle = load_bundle("synthea_patient.json")
+        >>> try:
+        ...     bundle = load_bundle({"resourceType": "Bundle", "entry": [...]})
+        ... except FHIRValidationError as e:
+        ...     print(e.report.model_dump())
+    """
+    if isinstance(source, Path):
+        data = _parse_bundle_json(source.read_text())
+    elif isinstance(source, str):
+        if source.lstrip().startswith("{"):
+            data = _parse_bundle_json(source)
+        else:
+            data = _parse_bundle_json(Path(source).read_text())
+    elif isinstance(source, dict):
+        data = source
+    else:
+        raise TypeError(
+            f"source must be a file path, JSON string, or dict, got {type(source)}"
+        )
+
+    resource_type = data.get("resourceType")
+    if resource_type != "Bundle":
+        raise FHIRValidationError(
+            ValidationReport(
+                valid=False,
+                resource_type=resource_type,
+                issues=[
+                    ValidationIssue(
+                        severity="fatal",
+                        code="structure",
+                        diagnostics=(
+                            f"Expected resourceType 'Bundle', got '{resource_type}'"
+                        ),
+                        expression="Bundle.resourceType",
+                    )
+                ],
+            )
+        )
+
+    # Validate the bundle skeleton and each entry resource independently, so
+    # a structural error in one entry doesn't mask issues in the others
+    issues: List[ValidationIssue] = []
+    entries = data.get("entry") or []
+    skeleton = {
+        **data,
+        "entry": [
+            {k: v for k, v in entry.items() if k != "resource"}
+            if isinstance(entry, dict)
+            else entry
+            for entry in entries
+        ],
+    }
+    skeleton_report = validate_resource(
+        skeleton, resource_type="Bundle", version=version
+    )
+    issues.extend(skeleton_report.issues)
+
+    for i, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            continue  # reported by the skeleton validation above
+        entry_resource = entry.get("resource")
+        if entry_resource is None:
+            continue
+        entry_report = validate_resource(entry_resource, version=version)
+        prefix = f"Bundle.entry[{i}].resource"
+        for issue in entry_report.issues:
+            # Rebase the expression from the entry's resource type onto the bundle path
+            suffix = ""
+            if issue.expression and "." in issue.expression:
+                suffix = "." + issue.expression.split(".", 1)[1]
+            issues.append(issue.model_copy(update={"expression": prefix + suffix}))
+
+    report = ValidationReport(
+        valid=not any(issue.severity in ("error", "fatal") for issue in issues),
+        resource_type="Bundle",
+        fhir_version=skeleton_report.fhir_version,
+        issues=issues,
+    )
+    if not report.valid:
+        raise FHIRValidationError(report)
+
+    bundle_class = get_fhir_resource("Bundle", version)
+    return bundle_class.model_validate(data)
+
+
+def _parse_bundle_json(text: str) -> Dict[str, Any]:
+    """Parse bundle JSON, raising FHIRValidationError on malformed input."""
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as e:
+        raise FHIRValidationError(
+            ValidationReport(
+                valid=False,
+                issues=[
+                    ValidationIssue(
+                        severity="fatal",
+                        code="structure",
+                        diagnostics=f"Invalid JSON: {e}",
+                    )
+                ],
+            )
+        ) from e
+    if not isinstance(data, dict):
+        raise FHIRValidationError(
+            ValidationReport(
+                valid=False,
+                issues=[
+                    ValidationIssue(
+                        severity="fatal",
+                        code="structure",
+                        diagnostics=f"Expected a JSON object, got {type(data).__name__}",
+                    )
+                ],
+            )
+        )
+    return data

--- a/tests/fhir/test_validation.py
+++ b/tests/fhir/test_validation.py
@@ -1,0 +1,273 @@
+import json
+
+import pytest
+from fhir.resources.R4B.bundle import Bundle
+from fhir.resources.R4B.condition import Condition
+from fhir.resources.R4B.operationoutcome import OperationOutcome
+
+from healthchain.fhir import (
+    FHIRValidationError,
+    ValidationReport,
+    create_resource_from_dict,
+    load_bundle,
+    validate_resource,
+)
+
+VALID_CONDITION = {
+    "resourceType": "Condition",
+    "subject": {"reference": "Patient/123"},
+    "code": {"text": "Hypertension"},
+}
+
+VALID_MEDICATION_STATEMENT = {
+    "resourceType": "MedicationStatement",
+    "status": "active",
+    "subject": {"reference": "Patient/123"},
+    "medicationCodeableConcept": {"text": "Aspirin"},
+}
+
+
+def test_validate_resource_valid_dict():
+    """A structurally valid resource dict produces a clean report."""
+    report = validate_resource(VALID_CONDITION)
+
+    assert report.valid is True
+    assert report.resource_type == "Condition"
+    assert report.fhir_version == "R4B"
+    assert report.issues == []
+
+
+def test_validate_resource_structural_errors():
+    """Invalid payload for a valid type reports issues with expressions."""
+    report = validate_resource(
+        {
+            "resourceType": "Condition",
+            "onsetDateTime": "not-a-date",
+            "bogusField": 1,
+        }
+    )
+
+    assert report.valid is False
+    issues_by_expression = {issue.expression: issue for issue in report.issues}
+    assert issues_by_expression["Condition.subject"].code == "required"
+    assert issues_by_expression["Condition.bogusField"].code == "structure"
+    assert issues_by_expression["Condition.onsetDateTime"].code == "value"
+    assert all(issue.severity == "error" for issue in report.issues)
+
+
+def test_validate_resource_binding_violation():
+    """A code outside a required binding is caught even though Pydantic accepts it."""
+    report = validate_resource({**VALID_MEDICATION_STATEMENT, "status": "recorded"})
+
+    assert report.valid is False
+    assert len(report.issues) == 1
+    issue = report.issues[0]
+    assert issue.code == "code-invalid"
+    assert issue.expression == "MedicationStatement.status"
+    assert "'recorded'" in issue.diagnostics
+    assert "active" in issue.diagnostics
+
+
+def test_validate_resource_binding_version_aware():
+    """'recorded' is invalid R4B vocabulary but valid R5 vocabulary."""
+    r5_statement = {
+        "resourceType": "MedicationStatement",
+        "status": "recorded",
+        "subject": {"reference": "Patient/123"},
+        "medication": {"concept": {"text": "Aspirin"}},
+    }
+    report = validate_resource(r5_statement, version="R5")
+
+    assert report.valid is True
+    assert report.fhir_version == "R5"
+
+
+def test_validate_resource_missing_resource_type():
+    """A dict without resourceType and no resource_type argument is fatal."""
+    report = validate_resource({"subject": {"reference": "Patient/123"}})
+
+    assert report.valid is False
+    assert report.issues[0].severity == "fatal"
+    assert report.issues[0].code == "structure"
+
+
+def test_validate_resource_unknown_resource_type():
+    """An unknown resource type reports not-supported."""
+    report = validate_resource({"resourceType": "NotAType"})
+
+    assert report.valid is False
+    assert report.issues[0].severity == "fatal"
+    assert report.issues[0].code == "not-supported"
+    assert report.resource_type == "NotAType"
+
+
+def test_validate_resource_explicit_type_argument():
+    """resource_type argument works for dicts without a resourceType key."""
+    resource = {k: v for k, v in VALID_CONDITION.items() if k != "resourceType"}
+    report = validate_resource(resource, resource_type="Condition")
+
+    assert report.valid is True
+    assert report.resource_type == "Condition"
+
+
+def test_validate_resource_model_instance():
+    """An instantiated resource validates, including binding checks."""
+    condition = Condition.model_validate(VALID_CONDITION)
+    report = validate_resource(condition)
+
+    assert report.valid is True
+    assert report.resource_type == "Condition"
+    assert report.fhir_version == "R4B"
+
+
+def test_validate_resource_model_instance_binding_violation():
+    """Binding checks run on model instances, catching spec-invalid codes."""
+    from fhir.resources.R4B.medicationstatement import MedicationStatement
+
+    statement = MedicationStatement.model_validate(
+        {**VALID_MEDICATION_STATEMENT, "status": "recorded"}
+    )
+    report = validate_resource(statement)
+
+    assert report.valid is False
+    assert report.issues[0].code == "code-invalid"
+    assert report.issues[0].expression == "MedicationStatement.status"
+
+
+def test_validation_report_serializes_to_json():
+    """Reports are JSON-serializable for agent tool output."""
+    report = validate_resource({"resourceType": "Condition"})
+    dumped = json.loads(report.model_dump_json())
+
+    assert dumped["valid"] is False
+    assert dumped["resource_type"] == "Condition"
+    assert dumped["issues"][0]["expression"] == "Condition.subject"
+
+
+def test_validation_report_to_operation_outcome():
+    """Reports convert to FHIR OperationOutcome resources."""
+    report = validate_resource({"resourceType": "Condition"})
+    outcome = report.to_operation_outcome()
+
+    assert isinstance(outcome, OperationOutcome)
+    assert outcome.issue[0].severity == "error"
+    assert outcome.issue[0].code == "required"
+    assert outcome.issue[0].expression == ["Condition.subject"]
+
+
+def test_validation_report_to_operation_outcome_valid():
+    """A valid report converts to an informational OperationOutcome."""
+    report = validate_resource(VALID_CONDITION)
+    outcome = report.to_operation_outcome()
+
+    assert outcome.issue[0].severity == "information"
+    assert outcome.issue[0].code == "informational"
+
+
+def test_load_bundle_from_dict():
+    """A valid bundle dict loads into a Bundle instance."""
+    bundle = load_bundle(
+        {
+            "resourceType": "Bundle",
+            "type": "collection",
+            "entry": [{"resource": VALID_CONDITION}],
+        }
+    )
+
+    assert isinstance(bundle, Bundle)
+    assert type(bundle.entry[0].resource).__name__ == "Condition"
+
+
+def test_load_bundle_from_json_string_and_file(tmp_path):
+    """Bundles load from JSON strings and file paths."""
+    bundle_json = json.dumps(
+        {
+            "resourceType": "Bundle",
+            "type": "collection",
+            "entry": [{"resource": VALID_MEDICATION_STATEMENT}],
+        }
+    )
+
+    from_string = load_bundle(bundle_json)
+    assert isinstance(from_string, Bundle)
+
+    bundle_file = tmp_path / "bundle.json"
+    bundle_file.write_text(bundle_json)
+    from_path = load_bundle(bundle_file)
+    assert isinstance(from_path, Bundle)
+    from_str_path = load_bundle(str(bundle_file))
+    assert isinstance(from_str_path, Bundle)
+
+
+def test_load_bundle_aggregates_entry_errors():
+    """Errors across multiple entries are aggregated with entry-indexed expressions."""
+    bad_bundle = {
+        "resourceType": "Bundle",
+        "type": "collection",
+        "entry": [
+            {"resource": VALID_CONDITION},
+            {"resource": {"resourceType": "Condition", "onsetDateTime": "bad"}},
+            {"resource": {**VALID_MEDICATION_STATEMENT, "status": "recorded"}},
+        ],
+    }
+
+    with pytest.raises(FHIRValidationError) as exc_info:
+        load_bundle(bad_bundle)
+
+    report = exc_info.value.report
+    assert report.valid is False
+    expressions = [issue.expression for issue in report.issues]
+    assert "Bundle.entry[1].resource.subject" in expressions
+    assert "Bundle.entry[1].resource.onsetDateTime" in expressions
+    assert "Bundle.entry[2].resource.status" in expressions
+
+
+def test_load_bundle_rejects_non_bundle():
+    """A resource that isn't a Bundle raises with a fatal issue."""
+    with pytest.raises(FHIRValidationError) as exc_info:
+        load_bundle(VALID_CONDITION)
+
+    report = exc_info.value.report
+    assert report.issues[0].severity == "fatal"
+    assert "Condition" in report.issues[0].diagnostics
+
+
+def test_load_bundle_rejects_malformed_json():
+    """Malformed JSON raises FHIRValidationError, not JSONDecodeError."""
+    with pytest.raises(FHIRValidationError) as exc_info:
+        load_bundle('{"resourceType": "Bundle",')
+
+    assert exc_info.value.report.issues[0].code == "structure"
+
+
+def test_load_bundle_missing_file():
+    """A nonexistent file path raises FileNotFoundError."""
+    with pytest.raises(FileNotFoundError):
+        load_bundle("/nonexistent/bundle.json")
+
+
+def test_create_resource_from_dict_raise_on_error():
+    """raise_on_error=True raises FHIRValidationError carrying the report."""
+    with pytest.raises(FHIRValidationError) as exc_info:
+        create_resource_from_dict(
+            {"onsetDateTime": "bad"}, "Condition", raise_on_error=True
+        )
+
+    report = exc_info.value.report
+    assert isinstance(report, ValidationReport)
+    assert report.valid is False
+    assert any(issue.expression == "Condition.subject" for issue in report.issues)
+
+
+def test_create_resource_from_dict_default_still_returns_none():
+    """Default behavior is unchanged: failures return None."""
+    assert create_resource_from_dict({"onsetDateTime": "bad"}, "Condition") is None
+
+
+def test_create_resource_from_dict_raise_on_error_valid_input():
+    """raise_on_error=True does not affect successful creation."""
+    resource = create_resource_from_dict(
+        VALID_CONDITION, "Condition", raise_on_error=True
+    )
+
+    assert isinstance(resource, Condition)


### PR DESCRIPTION
Adds an explicit, agent-callable validation surface to `healthchain.fhir` (friction-review work-plan item 2).

- `validate_resource()` — report-returning validation, never raises; structural checks plus required-binding checks on primitive `code` fields (catches spec-invalid codes Pydantic accepts, e.g. `status="recorded"` on R4B MedicationStatement); version-aware
- `ValidationReport`/`ValidationIssue` mirroring OperationOutcome issue fields, with a `to_operation_outcome()` escape hatch; JSON-serializable for agent tool loops
- `load_bundle()` — loads a Bundle from dict/JSON string/file path, validates every entry independently and aggregates issues into one `FHIRValidationError`
- `create_resource_from_dict(raise_on_error=True)` — opt-in raising path carrying the same report; default None-on-failure unchanged

Docstrings state exactly what is and is not checked (no CodeableConcept/ValueSet bindings, FHIRPath invariants, profiles, or reference integrity).

Closes #232. Advances #239 (stub 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)