### PR TITLE
feat(fhir): dosage support + fix invalid medication status default

### DIFF
--- a/docs/reference/utilities/fhir_helpers.md
+++ b/docs/reference/utilities/fhir_helpers.md
@@ -96,7 +96,7 @@ medication_statement["medication"]["concept"]["coding"][0]["display"]
 | Resource Type | Required Fields | Sensible Defaults | Common Use Cases |
 |--------------|-----------------|-------------------|------------------|
 | **Condition** | • `clinicalStatus`<br>• `subject` | • `clinicalStatus`: "active"<br>• `id`: auto-generated with "hc-" prefix | • Recording diagnoses<br>• Problem list items<br>• Active conditions |
-| **MedicationStatement** | • `subject`<br>• `status`<br>• `medication` | • `status`: "recorded"<br>• `id`: auto-generated with "hc-" prefix | • Current medications<br>• Medication history<br>• Prescribed medications |
+| **MedicationStatement** | • `subject`<br>• `status`<br>• `medication` | • `status`: "unknown"<br>• `id`: auto-generated with "hc-" prefix | • Current medications<br>• Medication history<br>• Prescribed medications |
 | **AllergyIntolerance** | • `patient` | • `id`: auto-generated with "hc-" prefix | • Allergies<br>• Intolerances<br>• Adverse reactions |
 | **DocumentReference** | • `type` | • `status`: "current"<br>• `date`: UTC now<br>• `description`: default text<br>• `content.attachment.title`: default text | • Clinical notes<br>• Lab reports<br>• Imaging reports |
 
@@ -165,7 +165,7 @@ Creates a new [**MedicationStatement**](https://www.hl7.org/fhir/medicationstate
     - [medication](https://www.hl7.org/fhir/medicationstatement-definitions.html#MedicationStatement.medication)
 
 !!! tip "Sensible Defaults"
-    `status` is set to "`recorded`"
+    `status` is set to "`unknown`"
 
 ```python
 from healthchain.fhir import create_medication_statement
@@ -187,7 +187,7 @@ print(medication.model_dump())
     {
         "resourceType": "MedicationStatement",
         "id": "hc-86a26eba-63f9-4017-b7b2-5b36f9bad5f1",
-        "status": "recorded",
+        "status": "unknown",
         "medicationCodeableConcept": {
             "coding": [{
                 "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
@@ -783,7 +783,7 @@ allergies = get_resources(bundle, "AllergyIntolerance")
                 "resource": {
                     "resourceType": "MedicationStatement",
                     "id": "hc-86a26eba-63f9-4017-b7b2-5b36f9bad5f1",
-                    "status": "recorded",
+                    "status": "unknown",
                     "medication": {
                         "concept": {
                             "coding": [{

--- a/healthchain/fhir/__init__.py
+++ b/healthchain/fhir/__init__.py
@@ -29,6 +29,7 @@ from healthchain.fhir.elementhelpers import (
     create_single_codeable_concept,
     create_single_reaction,
     create_single_attachment,
+    create_dosage,
 )
 
 from healthchain.fhir.readers import (
@@ -94,6 +95,7 @@ __all__ = [
     "create_single_codeable_concept",
     "create_single_reaction",
     "create_single_attachment",
+    "create_dosage",
     # Resource modification
     "set_condition_category",
     "add_provenance_metadata",

--- a/healthchain/fhir/elementhelpers.py
+++ b/healthchain/fhir/elementhelpers.py
@@ -12,6 +12,9 @@ from typing import Optional, List, Dict, Any
 from fhir.resources.R4B.codeableconcept import CodeableConcept
 from fhir.resources.R4B.coding import Coding
 from fhir.resources.R4B.attachment import Attachment
+from fhir.resources.R4B.dosage import Dosage
+from fhir.resources.R4B.quantity import Quantity
+from fhir.resources.R4B.timing import Timing
 from healthchain.fhir.utilities import _utc_now
 
 logger = logging.getLogger(__name__)
@@ -67,6 +70,71 @@ def create_single_reaction(
             "severity": severity,
         }
     ]
+
+
+def create_dosage(
+    text: Optional[str] = None,
+    route_code: Optional[str] = None,
+    route_display: Optional[str] = None,
+    route_system: Optional[str] = "http://snomed.info/sct",
+    dose_value: Optional[float] = None,
+    dose_unit: Optional[str] = None,
+    frequency: Optional[int] = None,
+    period: Optional[float] = None,
+    period_unit: Optional[str] = None,
+    as_needed: Optional[bool] = None,
+) -> Dosage:
+    """Create a minimal FHIR Dosage element.
+
+    Builds a minimum viable Dosage suitable for attaching to a
+    MedicationStatement or MedicationRequest. Only the fields you provide are
+    populated. For anything more complex, construct the FHIR Dosage directly.
+    https://build.fhir.org/dosage.html
+
+    Args:
+        text: Free-text dosage instructions (e.g. "1 tablet twice daily")
+        route_code: The route of administration code (e.g. SNOMED CT code for "oral")
+        route_display: The display name for the route code
+        route_system: The code system for the route (default: SNOMED CT)
+        dose_value: The numeric dose amount, set as doseAndRate.doseQuantity.value
+        dose_unit: The unit for the dose amount (e.g. "mg", "tablet")
+        frequency: How many times per period the dose is taken (Timing.repeat.frequency)
+        period: The length of the period (Timing.repeat.period)
+        period_unit: The unit of the period (e.g. "d" for day, "h" for hour)
+        as_needed: Whether the medication is taken as needed (asNeededBoolean)
+
+    Returns:
+        Dosage: A FHIR Dosage element populated with the provided fields
+    """
+    dosage_data: Dict[str, Any] = {}
+
+    if text is not None:
+        dosage_data["text"] = text
+
+    if route_code is not None:
+        dosage_data["route"] = create_single_codeable_concept(
+            code=route_code, display=route_display, system=route_system
+        )
+
+    if dose_value is not None or dose_unit is not None:
+        dosage_data["doseAndRate"] = [
+            {"doseQuantity": Quantity(value=dose_value, unit=dose_unit)}
+        ]
+
+    timing_repeat: Dict[str, Any] = {}
+    if frequency is not None:
+        timing_repeat["frequency"] = frequency
+    if period is not None:
+        timing_repeat["period"] = period
+    if period_unit is not None:
+        timing_repeat["periodUnit"] = period_unit
+    if timing_repeat:
+        dosage_data["timing"] = Timing(repeat=timing_repeat)
+
+    if as_needed is not None:
+        dosage_data["asNeededBoolean"] = as_needed
+
+    return Dosage(**dosage_data)
 
 
 def create_single_attachment(

--- a/healthchain/fhir/resourcehelpers.py
+++ b/healthchain/fhir/resourcehelpers.py
@@ -12,11 +12,12 @@ Parameters marked REQUIRED are required by FHIR specification.
 
 import logging
 
-from typing import List, Optional, Dict, Any
+from typing import List, Optional, Dict, Any, Union
 
 from fhir.resources.R4B.allergyintolerance import AllergyIntolerance
 from fhir.resources.R4B.condition import Condition
 from fhir.resources.R4B.documentreference import DocumentReference
+from fhir.resources.R4B.dosage import Dosage
 from fhir.resources.R4B.identifier import Identifier
 from fhir.resources.R4B.medicationstatement import MedicationStatement
 from fhir.resources.R4B.observation import Observation
@@ -35,12 +36,31 @@ from healthchain.fhir.utilities import _generate_id, _utc_now
 logger = logging.getLogger(__name__)
 
 
+def _warn_binding_issues(resource: Any) -> None:
+    """Warn (never raise) if a freshly built resource has spec-invalid codes.
+
+    Runs the required-binding check from ``healthchain.fhir.validation`` on the
+    resource instance and logs one warning per issue. This catches cases where a
+    helper produced a code outside the value set (e.g. R5 vocabulary on an R4B
+    model) that Pydantic does not reject.
+    """
+    from healthchain.fhir.validation import _check_bindings
+
+    for issue in _check_bindings(resource, resource.__class__.__name__):
+        logger.warning(
+            "FHIR binding check on %s: %s",
+            issue.expression or resource.__class__.__name__,
+            issue.diagnostics,
+        )
+
+
 def create_condition(
     subject: str,
     clinical_status: str = "active",
     code: Optional[str] = None,
     display: Optional[str] = None,
     system: Optional[str] = "http://snomed.info/sct",
+    onset: Optional[str] = None,
 ) -> Condition:
     """
     Create a minimal active FHIR Condition.
@@ -53,6 +73,8 @@ def create_condition(
         code: The condition code
         display: The display name for the condition
         system: The code system (default: SNOMED CT)
+        onset: When the condition began, as an ISO 8601 date/datetime string,
+            set as onsetDateTime (e.g. "2024-01-15" or "2024-01-15T09:00:00Z")
 
     Returns:
         Condition: A FHIR Condition resource with an auto-generated ID prefixed with 'hc-'
@@ -61,7 +83,7 @@ def create_condition(
         create_single_codeable_concept(code, display, system) if code else None
     )
 
-    return Condition(
+    condition = Condition(
         id=_generate_id(),
         subject=Reference(reference=subject),
         clinicalStatus=create_single_codeable_concept(
@@ -70,27 +92,36 @@ def create_condition(
             system="http://terminology.hl7.org/CodeSystem/condition-clinical",
         ),
         code=condition_code,
+        onsetDateTime=onset,
     )
+    _warn_binding_issues(condition)
+    return condition
 
 
 def create_medication_statement(
     subject: str,
-    status: Optional[str] = "recorded",
+    status: Optional[str] = "unknown",
     code: Optional[str] = None,
     display: Optional[str] = None,
     system: Optional[str] = "http://snomed.info/sct",
+    dosage: Optional[Union[str, Dosage, List[Dosage]]] = None,
 ) -> MedicationStatement:
     """
-    Create a minimal recorded FHIR MedicationStatement.
+    Create a minimal FHIR MedicationStatement.
     If you need to create a more complex medication statement, use the FHIR MedicationStatement resource directly.
     https://build.fhir.org/medicationstatement.html
 
     Args:
         subject: REQUIRED. Reference to the patient (e.g. "Patient/123")
-        status: REQUIRED. Status of the medication (default: recorded)
+        status: REQUIRED. Status of the medication. Default "unknown" (an R4B-valid
+            code that makes no clinical assertion). Allowed R4B values: active,
+            completed, entered-in-error, intended, stopped, on-hold, unknown, not-taken
         code: The medication code
         display: The display name for the medication
         system: The code system (default: SNOMED CT)
+        dosage: Dosage instructions. A plain string is wrapped as a single
+            free-text Dosage; a single Dosage is wrapped in a one-element list;
+            a list of Dosage elements is used as-is. See create_dosage().
 
     Returns:
         MedicationStatement: A FHIR MedicationStatement resource with an auto-generated ID prefixed with 'hc-'
@@ -99,12 +130,22 @@ def create_medication_statement(
         create_single_codeable_concept(code, display, system) if code else None
     )
 
-    return MedicationStatement(
+    if isinstance(dosage, str):
+        dosage_list: Optional[List[Dosage]] = [Dosage(text=dosage)]
+    elif isinstance(dosage, Dosage):
+        dosage_list = [dosage]
+    else:
+        dosage_list = dosage
+
+    medication_statement = MedicationStatement(
         id=_generate_id(),
         subject=Reference(reference=subject),
         status=status,
         medicationCodeableConcept=medication_concept,
+        dosage=dosage_list,
     )
+    _warn_binding_issues(medication_statement)
+    return medication_statement
 
 
 def create_allergy_intolerance(
@@ -131,11 +172,13 @@ def create_allergy_intolerance(
         create_single_codeable_concept(code, display, system) if code else None
     )
 
-    return AllergyIntolerance(
+    allergy = AllergyIntolerance(
         id=_generate_id(),
         patient=Reference(reference=patient),
         code=allergy_code,
     )
+    _warn_binding_issues(allergy)
+    return allergy
 
 
 def create_value_quantity_observation(
@@ -171,7 +214,7 @@ def create_value_quantity_observation(
 
     subject_ref = Reference(reference=subject) if subject is not None else None
 
-    return Observation(
+    observation = Observation(
         id=_generate_id(),
         status=status,
         code=create_single_codeable_concept(code, display, system),
@@ -181,6 +224,8 @@ def create_value_quantity_observation(
             value=value, unit=unit, system="http://unitsofmeasure.org", code=unit
         ),
     )
+    _warn_binding_issues(observation)
+    return observation
 
 
 def create_patient(
@@ -216,7 +261,9 @@ def create_patient(
             Identifier(system=identifier_system, value=identifier)
         ]
 
-    return Patient(**patient_data)
+    patient = Patient(**patient_data)
+    _warn_binding_issues(patient)
+    return patient
 
 
 def create_risk_assessment_from_prediction(
@@ -298,7 +345,9 @@ def create_risk_assessment_from_prediction(
     if comment:
         risk_assessment_data["note"] = [{"text": comment}]
 
-    return RiskAssessment(**risk_assessment_data)
+    risk_assessment = RiskAssessment(**risk_assessment_data)
+    _warn_binding_issues(risk_assessment)
+    return risk_assessment
 
 
 def create_document_reference(
@@ -325,7 +374,7 @@ def create_document_reference(
     Returns:
         DocumentReference: A FHIR DocumentReference resource with an auto-generated ID prefixed with 'hc-'
     """
-    return DocumentReference(
+    document_reference = DocumentReference(
         id=_generate_id(),
         status=status,
         date=_utc_now(),
@@ -341,6 +390,8 @@ def create_document_reference(
             }
         ],
     )
+    _warn_binding_issues(document_reference)
+    return document_reference
 
 
 def create_document_reference_content(

--- a/tests/fhir/test_helpers.py
+++ b/tests/fhir/test_helpers.py
@@ -5,7 +5,9 @@ from fhir.resources.R4B.codeableconcept import CodeableConcept
 from fhir.resources.R4B.documentreference import DocumentReference
 from fhir.resources.R4B.attachment import Attachment
 from fhir.resources.R4B.coding import Coding
+from fhir.resources.R4B.dosage import Dosage
 from datetime import datetime
+import logging
 
 
 from healthchain.fhir import (
@@ -15,6 +17,7 @@ from healthchain.fhir import (
     create_condition,
     create_medication_statement,
     create_allergy_intolerance,
+    create_dosage,
     set_condition_category,
     create_single_attachment,
     create_document_reference,
@@ -97,10 +100,115 @@ def test_create_medication_statement_minimal():
     assert medication.id.startswith("hc-")
     assert len(medication.id) > 3  # Ensure there's content after "hc-"
     assert medication.subject.reference == "Patient/123"
-    assert medication.status == "recorded"
+    assert medication.status == "unknown"
     assert medication.medicationCodeableConcept.coding[0].code == "123"
     assert medication.medicationCodeableConcept.coding[0].display == "Test Medication"
     assert medication.medicationCodeableConcept.coding[0].system == "http://test.system"
+
+
+def test_create_medication_statement_default_status_no_warning(caplog):
+    """The default 'unknown' status is valid R4B and must not warn."""
+    with caplog.at_level(logging.WARNING):
+        medication = create_medication_statement(subject="Patient/123", code="123")
+
+    assert medication.status == "unknown"
+    assert caplog.records == []
+
+
+def test_create_medication_statement_invalid_status_warns(caplog):
+    """An R5-only status like 'recorded' is invalid R4B and must warn (not raise)."""
+    with caplog.at_level(logging.WARNING):
+        medication = create_medication_statement(
+            subject="Patient/123", status="recorded", code="123"
+        )
+
+    # The resource is still built (warn, don't raise)
+    assert medication.status == "recorded"
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    assert record.levelno == logging.WARNING
+    assert "MedicationStatement.status" in record.getMessage()
+    assert "recorded" in record.getMessage()
+
+
+def test_create_medication_statement_with_dosage_string():
+    """A plain string dosage is wrapped as a single free-text Dosage."""
+    medication = create_medication_statement(
+        subject="Patient/123", code="123", dosage="1 tablet twice daily"
+    )
+
+    assert len(medication.dosage) == 1
+    assert medication.dosage[0].text == "1 tablet twice daily"
+
+
+def test_create_medication_statement_with_dosage_object():
+    """A single Dosage is wrapped in a one-element list."""
+    dosage = create_dosage(text="Take with food")
+    medication = create_medication_statement(
+        subject="Patient/123", code="123", dosage=dosage
+    )
+
+    assert len(medication.dosage) == 1
+    assert medication.dosage[0].text == "Take with food"
+
+
+def test_create_medication_statement_with_dosage_list():
+    """A list of Dosage elements is used as-is."""
+    dosages = [create_dosage(text="Morning"), create_dosage(text="Evening")]
+    medication = create_medication_statement(
+        subject="Patient/123", code="123", dosage=dosages
+    )
+
+    assert len(medication.dosage) == 2
+    assert medication.dosage[0].text == "Morning"
+    assert medication.dosage[1].text == "Evening"
+
+
+def test_create_dosage_text_only():
+    """A minimal dosage with only free text."""
+    dosage = create_dosage(text="1 tablet daily")
+
+    assert isinstance(dosage, Dosage)
+    assert dosage.text == "1 tablet daily"
+    assert dosage.route is None
+    assert dosage.doseAndRate is None
+    assert dosage.timing is None
+
+
+def test_create_dosage_full():
+    """A dosage with route, dose quantity, timing, and as-needed."""
+    dosage = create_dosage(
+        text="500 mg by mouth every 6 hours as needed",
+        route_code="26643006",
+        route_display="Oral route",
+        dose_value=500,
+        dose_unit="mg",
+        frequency=1,
+        period=6,
+        period_unit="h",
+        as_needed=True,
+    )
+
+    assert dosage.text == "500 mg by mouth every 6 hours as needed"
+    assert dosage.route.coding[0].code == "26643006"
+    assert dosage.route.coding[0].system == "http://snomed.info/sct"
+    assert dosage.doseAndRate[0].doseQuantity.value == 500
+    assert dosage.doseAndRate[0].doseQuantity.unit == "mg"
+    assert dosage.timing.repeat.frequency == 1
+    assert dosage.timing.repeat.period == 6
+    assert dosage.timing.repeat.periodUnit == "h"
+    assert dosage.asNeededBoolean is True
+
+
+def test_create_condition_with_onset():
+    """An onset string is set as onsetDateTime; omitting it changes nothing."""
+    condition = create_condition(
+        subject="Patient/123", code="38341003", onset="2024-01-15"
+    )
+    assert str(condition.onsetDateTime) == "2024-01-15"
+
+    without_onset = create_condition(subject="Patient/123", code="38341003")
+    assert without_onset.onsetDateTime is None
 
 
 def test_create_allergy_intolerance_minimal():


### PR DESCRIPTION
Friction-review work-plan items 1 + 5. Stacked on #240.

- `create_medication_statement`: default status `"recorded"` (R5 vocabulary, spec-invalid on the R4B model) is now `"unknown"`; callers relying on `"recorded"` must pass it explicitly — **behavior change, changelog note needed**
- `create_*` helpers now log a warning when a built resource contains a code outside a required binding (never raises)
- new `create_dosage` element helper (text, route, dose quantity, timing, as-needed)
- `dosage` kwarg on `create_medication_statement` (`str | Dosage | list[Dosage]`)
- additive `onset` kwarg on `create_condition` (sets `onsetDateTime`)

Closes #237. Closes #238.

🤖 Generated with [Claude Code](https://claude.com/claude-code)