### PR TITLE
feat(fhir): coded-entry readers (get_coded_entries, get_medications)

### DIFF
--- a/healthchain/fhir/__init__.py
+++ b/healthchain/fhir/__init__.py
@@ -32,8 +32,12 @@ from healthchain.fhir.elementhelpers import (
 )
 
 from healthchain.fhir.readers import (
+    CodedEntry,
+    EntryCoding,
     create_resource_from_dict,
     convert_prefetch_to_fhir_objects,
+    get_coded_entries,
+    get_medications,
     prefetch_to_bundle,
     read_content_attachment,
 )
@@ -100,8 +104,12 @@ __all__ = [
     "add_provenance_metadata",
     "add_coding_to_codeable_concept",
     # Conversions and readers
+    "CodedEntry",
+    "EntryCoding",
     "create_resource_from_dict",
     "convert_prefetch_to_fhir_objects",
+    "get_coded_entries",
+    "get_medications",
     "prefetch_to_bundle",
     "read_content_attachment",
     # Validation

--- a/healthchain/fhir/readers.py
+++ b/healthchain/fhir/readers.py
@@ -7,13 +7,207 @@ and reading data from FHIR resources.
 import logging
 import re
 
-from typing import Optional, Dict, Any, List
+from typing import Optional, Dict, Any, List, Union
+
+from pydantic import BaseModel, Field
 from fhir.resources.resource import Resource
+from fhir.resources.R4B.bundle import Bundle
 from fhir.resources.R4B.documentreference import DocumentReference
 
+from healthchain.fhir.bundlehelpers import get_resources, resolve_reference
 from healthchain.fhir.version import get_fhir_resource
 
 logger = logging.getLogger(__name__)
+
+_MEDICATION_TYPES = ("MedicationStatement", "MedicationRequest")
+_CLINICAL_STATUS_TYPES = ("Condition", "AllergyIntolerance")
+_DATE_FIELDS = ("authoredOn", "effectiveDateTime", "occurrenceDateTime", "recordedDate")
+
+
+class EntryCoding(BaseModel):
+    """A single coding (code/display/system) from a CodeableConcept."""
+
+    code: Optional[str] = None
+    display: Optional[str] = None
+    system: Optional[str] = None
+
+
+class CodedEntry(BaseModel):
+    """Flattened coded identity of a clinical resource.
+
+    JSON-serializable via ``model_dump()`` so it can be returned directly
+    from agent tools. ``code``/``display``/``system`` come from the first
+    coding; ``codings`` carries all of them.
+    """
+
+    code: Optional[str] = Field(
+        default=None, description="Code from the first coding, if any"
+    )
+    display: Optional[str] = Field(
+        default=None,
+        description="Display from the first coding, falling back to the concept text",
+    )
+    system: Optional[str] = Field(
+        default=None, description="Code system of the first coding, if any"
+    )
+    codings: List[EntryCoding] = Field(
+        default_factory=list, description="All codings of the concept"
+    )
+    status: Optional[str] = Field(
+        default=None,
+        description="Resource status; for Condition/AllergyIntolerance this is "
+        "the clinicalStatus code",
+    )
+    resource_type: str = Field(description="FHIR resource type of the entry")
+    resource_id: Optional[str] = Field(default=None, description="Resource id")
+    subject: Optional[str] = Field(
+        default=None, description="Reference string of subject/patient, if any"
+    )
+    date: Optional[str] = Field(
+        default=None,
+        description="First of authoredOn/effectiveDateTime/occurrenceDateTime/"
+        "recordedDate, ISO 8601",
+    )
+    value: Optional[float] = Field(
+        default=None, description="valueQuantity.value for value-bearing resources"
+    )
+    unit: Optional[str] = Field(
+        default=None, description="valueQuantity.unit for value-bearing resources"
+    )
+
+
+def _concept_codings(concept: Any) -> List[EntryCoding]:
+    """Flatten a CodeableConcept into EntryCodings.
+
+    A concept with text but no codings yields a single display-only entry.
+    """
+    if concept is None:
+        return []
+    text = getattr(concept, "text", None)
+    codings = [
+        EntryCoding(code=c.code, display=c.display or text, system=c.system)
+        for c in (getattr(concept, "coding", None) or [])
+    ]
+    if not codings and text:
+        codings = [EntryCoding(display=text)]
+    return codings
+
+
+def _resource_codings(bundle: Bundle, resource: Resource) -> List[EntryCoding]:
+    """Extract the coded identity of a resource, resolving medication[x]."""
+    if type(resource).__name__ in _MEDICATION_TYPES:
+        codings = _concept_codings(getattr(resource, "medicationCodeableConcept", None))
+        if not codings:
+            medication_ref = getattr(resource, "medicationReference", None)
+            if medication_ref is not None:
+                target = resolve_reference(bundle, medication_ref, parent=resource)
+                if target is not None:
+                    codings = _concept_codings(getattr(target, "code", None))
+        return codings
+    return _concept_codings(getattr(resource, "code", None))
+
+
+def _entry_status(resource: Resource) -> Optional[str]:
+    """Read the status of a resource; clinicalStatus for condition-shaped types."""
+    if type(resource).__name__ in _CLINICAL_STATUS_TYPES:
+        codings = _concept_codings(getattr(resource, "clinicalStatus", None))
+        return codings[0].code if codings else None
+    return getattr(resource, "status", None)
+
+
+def _entry_date(resource: Resource) -> Optional[str]:
+    """Read the first available date field as an ISO 8601 string."""
+    for field in _DATE_FIELDS:
+        value = getattr(resource, field, None)
+        if value is not None:
+            return value.isoformat() if hasattr(value, "isoformat") else str(value)
+    return None
+
+
+def get_coded_entries(
+    bundle: Bundle,
+    resource_type: Union[str, List[str]],
+    status: Optional[str] = None,
+) -> List[CodedEntry]:
+    """Read the flattened coded identity of resources in a bundle.
+
+    The read-side counterpart to the ``create_*`` helpers: instead of walking
+    nested CodeableConcepts by hand, get code/display/system/status and entry
+    metadata as flat records. Medication resources are handled specially:
+    ``medicationCodeableConcept`` is read directly, and ``medicationReference``
+    is resolved to its target (bundled or contained) Medication.
+
+    Resources with no coded identity at all (no codings and no concept text)
+    are skipped.
+
+    Args:
+        bundle: The bundle to read
+        resource_type: A resource type name or list of names
+            (e.g. "Condition" or ["MedicationStatement", "MedicationRequest"])
+        status: Only return entries with this status. For Condition and
+            AllergyIntolerance this matches the clinicalStatus code
+
+    Returns:
+        List of CodedEntry records, in bundle order per requested type
+
+    Example:
+        >>> bundle = load_bundle("synthea_patient.json")
+        >>> for entry in get_coded_entries(bundle, "Condition", status="active"):
+        ...     print(entry.code, entry.display, entry.date)
+        >>> meds = get_coded_entries(bundle, ["MedicationStatement", "MedicationRequest"])
+    """
+    types = [resource_type] if isinstance(resource_type, str) else list(resource_type)
+    entries: List[CodedEntry] = []
+    for type_name in types:
+        for resource in get_resources(bundle, type_name):
+            codings = _resource_codings(bundle, resource)
+            if not codings:
+                continue
+            entry_status = _entry_status(resource)
+            if status is not None and entry_status != status:
+                continue
+            subject = getattr(resource, "subject", None) or getattr(
+                resource, "patient", None
+            )
+            quantity = getattr(resource, "valueQuantity", None)
+            entries.append(
+                CodedEntry(
+                    code=codings[0].code,
+                    display=codings[0].display,
+                    system=codings[0].system,
+                    codings=codings,
+                    status=entry_status,
+                    resource_type=type_name,
+                    resource_id=getattr(resource, "id", None),
+                    subject=getattr(subject, "reference", None) if subject else None,
+                    date=_entry_date(resource),
+                    value=float(quantity.value)
+                    if quantity is not None and quantity.value is not None
+                    else None,
+                    unit=quantity.unit if quantity is not None else None,
+                )
+            )
+    return entries
+
+
+def get_medications(bundle: Bundle, status: Optional[str] = None) -> List[CodedEntry]:
+    """Read all medications in a bundle as flat coded entries.
+
+    Sugar over ``get_coded_entries`` spanning MedicationStatement and
+    MedicationRequest, with ``medicationReference`` resolved within the bundle.
+
+    Args:
+        bundle: The bundle to read
+        status: Only return medications with this status (e.g. "active")
+
+    Returns:
+        List of CodedEntry records for all medications found
+
+    Example:
+        >>> for med in get_medications(bundle, status="active"):
+        ...     print(med.code, med.display, med.system)
+    """
+    return get_coded_entries(bundle, list(_MEDICATION_TYPES), status=status)
 
 
 def _fix_timezone_naive_datetimes(data: Any) -> Any:

--- a/tests/fhir/test_readers.py
+++ b/tests/fhir/test_readers.py
@@ -1,0 +1,288 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from healthchain.fhir import (
+    CodedEntry,
+    get_coded_entries,
+    get_medications,
+    load_bundle,
+)
+
+FIXTURE_PATH = Path(__file__).parent.parent / "data" / "test_reference_bundle.json"
+
+
+@pytest.fixture
+def reference_bundle():
+    return load_bundle(FIXTURE_PATH)
+
+
+def _bundle_of(*resources: dict):
+    return load_bundle(
+        {
+            "resourceType": "Bundle",
+            "type": "collection",
+            "entry": [{"resource": r} for r in resources],
+        }
+    )
+
+
+def test_get_coded_entries_condition():
+    """Conditions flatten to code/display/system with clinicalStatus as status."""
+    bundle = _bundle_of(
+        {
+            "resourceType": "Condition",
+            "id": "c1",
+            "subject": {"reference": "Patient/123"},
+            "clinicalStatus": {
+                "coding": [
+                    {
+                        "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+                        "code": "active",
+                    }
+                ]
+            },
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://snomed.info/sct",
+                        "code": "38341003",
+                        "display": "Hypertension",
+                    }
+                ]
+            },
+            "recordedDate": "2024-01-15T09:00:00Z",
+        }
+    )
+
+    entries = get_coded_entries(bundle, "Condition")
+
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.code == "38341003"
+    assert entry.display == "Hypertension"
+    assert entry.system == "http://snomed.info/sct"
+    assert entry.status == "active"
+    assert entry.resource_type == "Condition"
+    assert entry.resource_id == "c1"
+    assert entry.subject == "Patient/123"
+    assert entry.date == "2024-01-15T09:00:00+00:00"
+
+
+def test_get_coded_entries_status_filter_clinical_status():
+    """The status filter matches clinicalStatus for condition-shaped types."""
+    active = {
+        "resourceType": "Condition",
+        "subject": {"reference": "Patient/123"},
+        "clinicalStatus": {"coding": [{"code": "active"}]},
+        "code": {"coding": [{"code": "111"}]},
+    }
+    resolved = {
+        "resourceType": "Condition",
+        "subject": {"reference": "Patient/123"},
+        "clinicalStatus": {"coding": [{"code": "resolved"}]},
+        "code": {"coding": [{"code": "222"}]},
+    }
+    bundle = _bundle_of(active, resolved)
+
+    entries = get_coded_entries(bundle, "Condition", status="active")
+
+    assert [entry.code for entry in entries] == ["111"]
+
+
+def test_get_coded_entries_multiple_types():
+    """A list of types returns entries grouped in the requested type order."""
+    bundle = _bundle_of(
+        {
+            "resourceType": "MedicationStatement",
+            "status": "active",
+            "subject": {"reference": "Patient/123"},
+            "medicationCodeableConcept": {"coding": [{"code": "313782"}]},
+        },
+        {
+            "resourceType": "Condition",
+            "subject": {"reference": "Patient/123"},
+            "code": {"coding": [{"code": "38341003"}]},
+        },
+    )
+
+    entries = get_coded_entries(bundle, ["Condition", "MedicationStatement"])
+
+    assert [entry.resource_type for entry in entries] == [
+        "Condition",
+        "MedicationStatement",
+    ]
+
+
+def test_get_coded_entries_all_codings_kept():
+    """code/display/system come from the first coding; codings keeps all."""
+    bundle = _bundle_of(
+        {
+            "resourceType": "Condition",
+            "subject": {"reference": "Patient/123"},
+            "code": {
+                "coding": [
+                    {"system": "http://snomed.info/sct", "code": "38341003"},
+                    {"system": "http://hl7.org/fhir/sid/icd-10-cm", "code": "I10"},
+                ]
+            },
+        }
+    )
+
+    entry = get_coded_entries(bundle, "Condition")[0]
+
+    assert entry.code == "38341003"
+    assert len(entry.codings) == 2
+    assert entry.codings[1].code == "I10"
+    assert entry.codings[1].system == "http://hl7.org/fhir/sid/icd-10-cm"
+
+
+def test_get_coded_entries_text_only_concept():
+    """A concept with text but no codings yields a display-only entry."""
+    bundle = _bundle_of(
+        {
+            "resourceType": "Condition",
+            "subject": {"reference": "Patient/123"},
+            "code": {"text": "Headache"},
+        }
+    )
+
+    entry = get_coded_entries(bundle, "Condition")[0]
+
+    assert entry.code is None
+    assert entry.display == "Headache"
+
+
+def test_get_coded_entries_skips_resources_without_coded_identity():
+    """Resources with no code and no text are skipped, not returned empty."""
+    bundle = _bundle_of(
+        {
+            "resourceType": "Condition",
+            "subject": {"reference": "Patient/123"},
+        }
+    )
+
+    assert get_coded_entries(bundle, "Condition") == []
+    assert get_coded_entries(bundle, "Patient") == []
+
+
+def test_get_coded_entries_observation_value():
+    """Value-bearing Observations carry value/unit and effective date."""
+    bundle = _bundle_of(
+        {
+            "resourceType": "Observation",
+            "status": "final",
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "8480-6",
+                        "display": "Systolic blood pressure",
+                    }
+                ]
+            },
+            "subject": {"reference": "Patient/123"},
+            "effectiveDateTime": "2024-02-01T08:30:00Z",
+            "valueQuantity": {"value": 140, "unit": "mmHg"},
+        }
+    )
+
+    entry = get_coded_entries(bundle, "Observation")[0]
+
+    assert entry.code == "8480-6"
+    assert entry.status == "final"
+    assert entry.value == 140.0
+    assert entry.unit == "mmHg"
+    assert entry.date == "2024-02-01T08:30:00+00:00"
+
+
+def test_get_coded_entries_resolves_medication_reference(reference_bundle):
+    """medicationReference resolves to the bundled Medication's code."""
+    entries = get_coded_entries(reference_bundle, "MedicationRequest")
+
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.code == "313782"
+    assert entry.display == "Acetaminophen 325 MG Oral Tablet"
+    assert entry.system == "http://www.nlm.nih.gov/research/umls/rxnorm"
+    assert entry.status == "active"
+    assert entry.subject == "urn:uuid:11111111-1111-1111-1111-111111111111"
+
+
+def test_get_coded_entries_resolves_contained_medication():
+    """medicationReference to a contained Medication resolves via parent."""
+    bundle = _bundle_of(
+        {
+            "resourceType": "MedicationStatement",
+            "status": "active",
+            "subject": {"reference": "Patient/123"},
+            "medicationReference": {"reference": "#med-1"},
+            "contained": [
+                {
+                    "resourceType": "Medication",
+                    "id": "med-1",
+                    "code": {"coding": [{"code": "197361", "display": "Amlodipine"}]},
+                }
+            ],
+        }
+    )
+
+    entry = get_coded_entries(bundle, "MedicationStatement")[0]
+
+    assert entry.code == "197361"
+    assert entry.display == "Amlodipine"
+
+
+def test_get_coded_entries_unresolvable_medication_reference_skipped():
+    """A medication with an unresolvable reference has no identity and is skipped."""
+    bundle = _bundle_of(
+        {
+            "resourceType": "MedicationStatement",
+            "status": "active",
+            "subject": {"reference": "Patient/123"},
+            "medicationReference": {"reference": "Medication/nowhere"},
+        }
+    )
+
+    assert get_coded_entries(bundle, "MedicationStatement") == []
+
+
+def test_get_medications_spans_both_types(reference_bundle):
+    """get_medications covers MedicationStatement and MedicationRequest."""
+    statement_bundle = _bundle_of(
+        {
+            "resourceType": "MedicationStatement",
+            "status": "active",
+            "subject": {"reference": "Patient/123"},
+            "medicationCodeableConcept": {"coding": [{"code": "197361"}]},
+        },
+        {
+            "resourceType": "MedicationRequest",
+            "status": "stopped",
+            "intent": "order",
+            "subject": {"reference": "Patient/123"},
+            "medicationCodeableConcept": {"coding": [{"code": "313782"}]},
+        },
+    )
+
+    medications = get_medications(statement_bundle)
+    assert {med.code for med in medications} == {"197361", "313782"}
+
+    active_only = get_medications(statement_bundle, status="active")
+    assert [med.code for med in active_only] == ["197361"]
+
+    fixture_medications = get_medications(reference_bundle)
+    assert [med.code for med in fixture_medications] == ["313782"]
+
+
+def test_coded_entry_serializes_to_json(reference_bundle):
+    """CodedEntry records are JSON-serializable for agent tool output."""
+    entry = get_medications(reference_bundle)[0]
+
+    dumped = json.loads(entry.model_dump_json())
+
+    assert dumped["code"] == "313782"
+    assert dumped["resource_type"] == "MedicationRequest"
+    assert isinstance(dumped["codings"], list)
+    assert isinstance(entry, CodedEntry)


### PR DESCRIPTION
Friction-review work-plan item 4. Stacked on #242 (uses `resolve_reference` and the reference fixture).

- `get_coded_entries(bundle, resource_type, status=None)` — flattens clinical resources to `CodedEntry` records: code/display/system from the first coding plus a `codings` list with all of them, clinicalStatus-aware status extraction and filtering (Condition/AllergyIntolerance), subject/date metadata, and `value`/`unit` for value-bearing Observations
- `medicationReference` resolved via `resolve_reference`, including contained Medications
- `get_medications(bundle, status=None)` — sugar spanning MedicationStatement + MedicationRequest
- `CodedEntry`/`EntryCoding` are Pydantic models (`model_dump()` for agent tool output)
- design note: text-only concepts (text, no codings) are included as display-only entries rather than skipped; resources with no coded identity at all are skipped

Closes #233.

🤖 Generated with [Claude Code](https://claude.com/claude-code)