### PR TITLE
feat(terminology): terminology lookup seam with LocalCodeLookup

### DIFF
--- a/healthchain/terminology/__init__.py
+++ b/healthchain/terminology/__init__.py
@@ -1,0 +1,24 @@
+"""Terminology lookup for HealthChain.
+
+A small seam for mapping free text to codings: the ``TerminologyLookup``
+protocol, the ``Coding`` model, and ``LocalCodeLookup`` — an in-process
+implementation over a demo catalog (RxNorm/LOINC/ICD-10-CM) for offline
+demos and tests. Real terminology services implement the same protocol.
+"""
+
+from healthchain.terminology.base import Coding, TerminologyLookup
+from healthchain.terminology.local import (
+    ICD10CM,
+    LOINC,
+    RXNORM,
+    LocalCodeLookup,
+)
+
+__all__ = [
+    "Coding",
+    "TerminologyLookup",
+    "LocalCodeLookup",
+    "RXNORM",
+    "LOINC",
+    "ICD10CM",
+]

--- a/healthchain/terminology/base.py
+++ b/healthchain/terminology/base.py
@@ -1,0 +1,46 @@
+"""Terminology lookup protocol and coding model.
+
+Defines the seam between HealthChain and terminology services: anything with
+a ``search(text, system) -> list[Coding]`` method is a terminology lookup.
+``LocalCodeLookup`` is the shipped in-process implementation; real terminology
+services (a FHIR ``$lookup`` endpoint, a hosted MCP server) plug in behind the
+same signature.
+"""
+
+from typing import List, Optional, Protocol, runtime_checkable
+
+from pydantic import BaseModel, Field
+
+
+class Coding(BaseModel):
+    """A terminology coding: code, display, and the system it belongs to.
+
+    Version-agnostic and JSON-serializable via ``model_dump()`` so it can be
+    returned directly from agent tools.
+    """
+
+    code: str = Field(description="The code within the system")
+    display: str = Field(description="Human-readable display name")
+    system: str = Field(description="Canonical URI of the code system")
+
+
+@runtime_checkable
+class TerminologyLookup(Protocol):
+    """Protocol for terminology lookup implementations.
+
+    Implementations search a code system (or all systems they know) for
+    codings matching a free-text query and return ranked candidates —
+    never a guess. Agents should use a returned code, not invent one.
+    """
+
+    def search(self, text: str, system: Optional[str] = None) -> List[Coding]:
+        """Search for codings matching free text.
+
+        Args:
+            text: Free-text query (e.g. a medication or condition name)
+            system: Restrict results to this code system URI
+
+        Returns:
+            Ranked list of candidate codings; empty if nothing matches
+        """
+        ...

--- a/healthchain/terminology/local.py
+++ b/healthchain/terminology/local.py
@@ -1,0 +1,142 @@
+"""In-process terminology lookup backed by a small demo catalog.
+
+The bundled catalog covers common medications (RxNorm), lab and vital-sign
+observations (LOINC), and conditions (ICD-10-CM) — license-free systems only,
+deliberately no SNOMED CT. It exists so demos, tests, and generated projects
+work offline with zero setup; it is NOT a terminology service and covers only
+a few dozen concepts. For real coverage, put a proper terminology service
+behind the same ``TerminologyLookup`` protocol.
+"""
+
+from typing import Iterable, List, Optional, Union
+
+from healthchain.terminology.base import Coding
+
+RXNORM = "http://www.nlm.nih.gov/research/umls/rxnorm"
+LOINC = "http://loinc.org"
+ICD10CM = "http://hl7.org/fhir/sid/icd-10-cm"
+
+_DEMO_CATALOG: List[Coding] = [
+    # Medications (RxNorm)
+    Coding(code="243670", display="aspirin 81 MG Oral Tablet", system=RXNORM),
+    Coding(
+        code="209387",
+        display="Acetaminophen 325 MG Oral Tablet [Tylenol]",
+        system=RXNORM,
+    ),
+    Coding(
+        code="313820", display="Acetaminophen 160 MG Chewable Tablet", system=RXNORM
+    ),
+    Coding(
+        code="866427",
+        display="24 HR metoprolol succinate 25 MG Extended Release Oral Tablet",
+        system=RXNORM,
+    ),
+    Coding(
+        code="866412",
+        display="24 HR metoprolol succinate 100 MG Extended Release Oral Tablet",
+        system=RXNORM,
+    ),
+    Coding(code="308136", display="amLODIPine 2.5 MG Oral Tablet", system=RXNORM),
+    Coding(code="197319", display="Allopurinol 100 MG Oral Tablet", system=RXNORM),
+    Coding(code="308192", display="Amoxicillin 500 MG Oral Tablet", system=RXNORM),
+    Coding(code="309362", display="Clopidogrel 75 MG Oral Tablet", system=RXNORM),
+    Coding(code="310965", display="Ibuprofen 200 MG Oral Tablet", system=RXNORM),
+    Coding(code="314076", display="lisinopril 10 MG Oral Tablet", system=RXNORM),
+    Coding(
+        code="860975",
+        display="24 HR metFORMIN hydrochloride 500 MG Extended Release Oral Tablet",
+        system=RXNORM,
+    ),
+    Coding(code="312961", display="simvastatin 20 MG Oral Tablet", system=RXNORM),
+    # Conditions (ICD-10-CM)
+    Coding(code="I10", display="Essential (primary) hypertension", system=ICD10CM),
+    Coding(
+        code="E11.9",
+        display="Type 2 diabetes mellitus without complications",
+        system=ICD10CM,
+    ),
+    Coding(code="J45.909", display="Unspecified asthma, uncomplicated", system=ICD10CM),
+    Coding(
+        code="J44.9",
+        display="Chronic obstructive pulmonary disease, unspecified",
+        system=ICD10CM,
+    ),
+    Coding(code="I50.9", display="Heart failure, unspecified", system=ICD10CM),
+    Coding(code="D64.9", display="Anemia, unspecified", system=ICD10CM),
+    # Observations (LOINC)
+    Coding(code="8302-2", display="Body height", system=LOINC),
+    Coding(code="29463-7", display="Body weight", system=LOINC),
+    Coding(
+        code="85354-9",
+        display="Blood pressure panel with all children optional",
+        system=LOINC,
+    ),
+    Coding(
+        code="4548-4",
+        display="Hemoglobin A1c/Hemoglobin.total in Blood",
+        system=LOINC,
+    ),
+    Coding(
+        code="2093-3",
+        display="Cholesterol [Mass/volume] in Serum or Plasma",
+        system=LOINC,
+    ),
+    Coding(code="718-7", display="Hemoglobin [Mass/volume] in Blood", system=LOINC),
+]
+
+
+class LocalCodeLookup:
+    """Terminology lookup over an in-memory catalog.
+
+    Implements the ``TerminologyLookup`` protocol. Matching: every word of
+    the query must appear (case-insensitive substring) in some word of the
+    display name, so brand names, ingredients, and strengths all narrow the
+    match. Results are ranked shortest-display-first — the tightest match
+    for the query comes first.
+
+    Args:
+        catalog: Codings to search over instead of the bundled demo catalog.
+            Accepts Coding instances or dicts with code/display/system keys
+
+    Example:
+        >>> lookup = LocalCodeLookup()
+        >>> lookup.search("metoprolol 25")[0].code
+        '866427'
+        >>> lookup.search("hypertension", system=ICD10CM)[0].code
+        'I10'
+        >>> site_lookup = LocalCodeLookup(catalog=my_formulary)
+    """
+
+    def __init__(self, catalog: Optional[Iterable[Union[Coding, dict]]] = None) -> None:
+        source = _DEMO_CATALOG if catalog is None else catalog
+        self._catalog: List[Coding] = [
+            entry if isinstance(entry, Coding) else Coding.model_validate(entry)
+            for entry in source
+        ]
+
+    def search(self, text: str, system: Optional[str] = None) -> List[Coding]:
+        """Search the catalog for codings matching free text.
+
+        Args:
+            text: Free-text query (e.g. "metoprolol 25", "type 2 diabetes")
+            system: Restrict results to this code system URI
+
+        Returns:
+            Ranked list of candidate codings (shortest display first);
+            empty if nothing matches
+        """
+        tokens = text.lower().split()
+        if not tokens:
+            return []
+
+        matches = [
+            entry
+            for entry in self._catalog
+            if (system is None or entry.system == system)
+            and all(
+                any(token in word for word in entry.display.lower().split())
+                for token in tokens
+            )
+        ]
+        return sorted(matches, key=lambda entry: len(entry.display))

--- a/tests/terminology/test_lookup.py
+++ b/tests/terminology/test_lookup.py
@@ -1,0 +1,110 @@
+import json
+
+from healthchain.terminology import (
+    ICD10CM,
+    LOINC,
+    RXNORM,
+    Coding,
+    LocalCodeLookup,
+    TerminologyLookup,
+)
+
+
+def test_search_by_name():
+    """A single-word query matches displays containing it."""
+    lookup = LocalCodeLookup()
+
+    results = lookup.search("lisinopril")
+
+    assert len(results) == 1
+    assert results[0].code == "314076"
+    assert results[0].system == RXNORM
+
+
+def test_search_multi_token_narrows():
+    """Every query token must match, so strengths narrow brand/ingredient hits."""
+    lookup = LocalCodeLookup()
+
+    all_metoprolol = lookup.search("metoprolol")
+    assert len(all_metoprolol) == 2
+
+    narrowed = lookup.search("metoprolol 25")
+    assert [coding.code for coding in narrowed] == ["866427"]
+
+
+def test_search_case_insensitive():
+    """Matching ignores case in both query and display."""
+    lookup = LocalCodeLookup()
+
+    assert lookup.search("AMLODIPINE") == lookup.search("amlodipine")
+    assert len(lookup.search("Hypertension")) == 1
+
+
+def test_search_system_filter():
+    """The system argument restricts results to one code system."""
+    lookup = LocalCodeLookup()
+
+    assert lookup.search("hemoglobin", system=LOINC) != []
+    assert lookup.search("hemoglobin", system=RXNORM) == []
+    assert lookup.search("hypertension", system=ICD10CM)[0].code == "I10"
+
+
+def test_search_ranked_shortest_display_first():
+    """Results are ranked with the tightest (shortest) display first."""
+    lookup = LocalCodeLookup()
+
+    results = lookup.search("acetaminophen")
+
+    assert len(results) == 2
+    displays = [coding.display for coding in results]
+    assert displays == sorted(displays, key=len)
+
+
+def test_search_no_match_returns_empty():
+    """Unmatched or empty queries return an empty list, never raise."""
+    lookup = LocalCodeLookup()
+
+    assert lookup.search("warfarin") == []
+    assert lookup.search("") == []
+    assert lookup.search("   ") == []
+
+
+def test_custom_catalog():
+    """A site-specific catalog replaces the demo catalog entirely."""
+    lookup = LocalCodeLookup(
+        catalog=[
+            Coding(code="123", display="Testdrug 10 MG Tablet", system=RXNORM),
+            {"code": "456", "display": "Other Testdrug", "system": RXNORM},
+        ]
+    )
+
+    assert [coding.code for coding in lookup.search("testdrug")] == ["456", "123"]
+    assert lookup.search("aspirin") == []
+
+
+def test_local_lookup_satisfies_protocol():
+    """LocalCodeLookup structurally implements TerminologyLookup."""
+    assert isinstance(LocalCodeLookup(), TerminologyLookup)
+
+
+def test_demo_catalog_has_no_snomed():
+    """The bundled catalog ships license-free systems only."""
+    lookup = LocalCodeLookup()
+
+    systems = {coding.system for coding in lookup._catalog}
+
+    assert systems == {RXNORM, LOINC, ICD10CM}
+    assert not any("snomed" in system for system in systems)
+
+
+def test_coding_serializes_to_json():
+    """Codings are JSON-serializable for agent tool output."""
+    coding = LocalCodeLookup().search("aspirin")[0]
+
+    dumped = json.loads(coding.model_dump_json())
+
+    assert dumped == {
+        "code": "243670",
+        "display": "aspirin 81 MG Oral Tablet",
+        "system": RXNORM,
+    }


### PR DESCRIPTION
Friction-review work-plan item 6 (friction stub 7). Independent of the FHIR branch train — no dependencies.

- `healthchain/terminology/` — new subpackage: `TerminologyLookup` protocol (`search(text, system) -> list[Coding]`, runtime-checkable) and a version-agnostic `Coding` model
- `LocalCodeLookup` — in-process lookup over a license-free demo catalog (RxNorm medications, LOINC observations, ICD-10-CM conditions — deliberately no SNOMED CT; a test pins that invariant); every query token must match a display word, results ranked shortest-display-first; custom catalogs via constructor arg
- docstrings state plainly this is a demo catalog, not a terminology service; real services (FHIR `$lookup`, MCP-backed lookups) implement the same protocol

Part of #239.

🤖 Generated with [Claude Code](https://claude.com/claude-code)