### PR TITLE
docs: document the agent-toolkit surface (validation, readers, terminology)

### DIFF
--- a/docs/api/terminology.md
+++ b/docs/api/terminology.md
@@ -1,0 +1,3 @@
+# Terminology
+
+::: healthchain.terminology

--- a/docs/reference/utilities/fhir_helpers.md
+++ b/docs/reference/utilities/fhir_helpers.md
@@ -58,25 +58,25 @@ For example, as an ML practitioner, you may only care about extracting and inser
 medication_statement = {
     "resourceType": "MedicationStatement",
     "status": "active",  # required
-    "medication": {  # required
-        "concept": {
-            "coding": [
-                {
-                    "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
-                    "code": "1049221",
-                    "display": "Acetaminophen 325 MG Oral Tablet",
-                }
-            ]
-        }
+    "medicationCodeableConcept": {  # required
+        "coding": [
+            {
+                "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+                "code": "1049221",
+                "display": "Acetaminophen 325 MG Oral Tablet",
+            }
+        ]
     },
     "subject": {  # required
         "reference": "Patient/example"
     },
 }
 
-medication_statement["medication"]["concept"]["coding"][0]["code"]
-medication_statement["medication"]["concept"]["coding"][0]["display"]
+medication_statement["medicationCodeableConcept"]["coding"][0]["code"]
+medication_statement["medicationCodeableConcept"]["coding"][0]["display"]
 ```
+
+(And that's the easy case — if the resource uses `medicationReference` instead, you first have to find the referenced Medication elsewhere in the bundle. [get_coded_entries()](#get_coded_entries) below handles both for you.)
 
 !!! tip "Sensible Defaults for Resource Creation"
     The `fhir` `create_*` functions create FHIR resources with sensible defaults, automatically setting:
@@ -88,8 +88,8 @@ medication_statement["medication"]["concept"]["coding"][0]["display"]
 
 !!! important "Validation of FHIR Resources"
     Internally, HealthChain uses [fhir.resources](https://github.com/nazrulworld/fhir.resources) to validate FHIR resources, which is powered by [Pydantic V2](https://docs.pydantic.dev/latest/).
-    These helpers create minimal valid FHIR objects to help you get started easily.
-    :octicons-alert-16: **ALWAYS check that the sensible defaults fit your needs, and validate your resource!**
+    These helpers create minimal valid FHIR objects to help you get started easily, and log a warning if a produced resource contains a code outside a required value set.
+    :octicons-alert-16: **ALWAYS check that the sensible defaults fit your needs, and validate your resource!** Use [validate_resource()](#validate_resource) to get an explicit validation report.
 
 ### Overview
 
@@ -122,6 +122,7 @@ condition = create_condition(
     code="38341003",
     display="Hypertension",
     system="http://snomed.info/sct",
+    onset="2024-01-15",  # optional, sets onsetDateTime
 )
 
 # Output the created resource
@@ -149,7 +150,8 @@ print(condition.model_dump())
         },
         "subject": {
             "reference": "Patient/123"
-        }
+        },
+        "onsetDateTime": "2024-01-15"
     }
     ```
 
@@ -182,6 +184,20 @@ medication = create_medication_statement(
 print(medication.model_dump())
 ```
 
+Dosage instructions can be attached with the `dosage` argument — pass a plain string for free-text instructions, or a structured [Dosage](#create_dosage) built with `create_dosage()`:
+
+```python
+from healthchain.fhir import create_dosage, create_medication_statement
+
+medication = create_medication_statement(
+    subject="Patient/123",
+    status="active",
+    code="1049221",
+    display="Acetaminophen 325 MG Oral Tablet",
+    dosage="1 tablet twice daily",  # or create_dosage(...) / [Dosage, ...]
+)
+```
+
 ??? example "Example Output JSON"
     ```json
     {
@@ -198,6 +214,55 @@ print(medication.model_dump())
         "subject": {
             "reference": "Patient/123"
         }
+    }
+    ```
+
+---
+
+### create_dosage()
+
+Creates a [**Dosage**](https://build.fhir.org/dosage.html) element for attaching to medication resources. Only the fields you provide are populated.
+
+```python
+from healthchain.fhir import create_dosage, create_medication_statement
+
+dosage = create_dosage(
+    text="1 tablet twice daily",
+    route_code="26643006",
+    route_display="Oral route",
+    dose_value=325.0,
+    dose_unit="mg",
+    frequency=2,
+    period=1.0,
+    period_unit="d",
+)
+
+medication = create_medication_statement(
+    subject="Patient/123",
+    status="active",
+    code="1049221",
+    display="Acetaminophen 325 MG Oral Tablet",
+    dosage=dosage,
+)
+```
+
+??? example "Example Output JSON (dosage element)"
+    ```json
+    {
+        "text": "1 tablet twice daily",
+        "timing": {
+            "repeat": {"frequency": 2, "period": 1.0, "periodUnit": "d"}
+        },
+        "route": {
+            "coding": [{
+                "system": "http://snomed.info/sct",
+                "code": "26643006",
+                "display": "Oral route"
+            }]
+        },
+        "doseAndRate": [{
+            "doseQuantity": {"value": 325.0, "unit": "mg"}
+        }]
     }
     ```
 
@@ -507,6 +572,36 @@ for condition in conditions:
 
 ---
 
+### resolve_reference()
+
+Resolves a FHIR [**Reference**](https://www.hl7.org/fhir/references.html) to its target resource within a bundle — the read-side counterpart to `add_resource()`.
+
+Handles the reference styles found in real bundles:
+
+- `urn:uuid:...` fullUrls (Synthea transaction bundles)
+- Relative `Type/id` references, including against absolute fullUrl tails
+- Contained resources (`#id`), via the `parent` argument
+
+```python
+from healthchain.fhir import get_resources, load_bundle, resolve_reference
+
+bundle = load_bundle("synthea_patient.json")
+
+med_request = get_resources(bundle, "MedicationRequest")[0]
+
+# Resolve the medication the request points to
+medication = resolve_reference(bundle, med_request.medicationReference)
+print(medication.code.coding[0].display)
+
+# Contained references need the owning resource as parent
+requester = resolve_reference(bundle, "#requester-1", parent=med_request)
+```
+
+!!! note "Never raises"
+    `resolve_reference` is a best-effort read helper: unresolvable or malformed references return `None` rather than raising.
+
+---
+
 ### set_resources()
 
 Sets or updates resources of a specific type in a [**Bundle**](https://www.hl7.org/fhir/bundle.html).
@@ -671,6 +766,107 @@ print(merged.model_dump())
 
 ---
 
+## Reading Coded Entries
+
+Reading clinical data out of a bundle usually means walking nested CodeableConcepts, special-casing `medication[x]`, and chasing references. `get_coded_entries()` does that walk for you and returns flat, JSON-serializable records — designed for feeding summaries, ML features, or agent tools.
+
+### get_coded_entries()
+
+Returns a `CodedEntry` record for each resource of the requested type(s):
+
+```python
+from healthchain.fhir import get_coded_entries, load_bundle
+
+bundle = load_bundle("synthea_patient.json")
+
+for entry in get_coded_entries(bundle, "Condition", status="active"):
+    print(entry.code, entry.display, entry.system, entry.date)
+
+# Multiple types in one call
+entries = get_coded_entries(bundle, ["Condition", "Observation"])
+```
+
+Each `CodedEntry` is a Pydantic model with:
+
+| Field | Description |
+|-------|-------------|
+| `code` / `display` / `system` | From the first coding (display falls back to the concept text) |
+| `codings` | *All* codings of the concept, not just the first |
+| `status` | Resource status — for Condition/AllergyIntolerance this is the `clinicalStatus` code, and the `status` filter matches it |
+| `resource_type` / `resource_id` | Where the entry came from |
+| `subject` | The `subject`/`patient` reference string |
+| `date` | First of `authoredOn`/`effectiveDateTime`/`occurrenceDateTime`/`recordedDate`, ISO 8601 |
+| `value` / `unit` | `valueQuantity` for value-bearing Observations |
+
+!!! note "What's included"
+    Concepts with text but no codings are included as display-only entries (`code=None`) — common for AI-extracted data that hasn't been coded yet. Resources with no coded identity at all are skipped.
+
+### get_medications()
+
+Sugar over `get_coded_entries()` spanning **MedicationStatement** and **MedicationRequest**. `medicationCodeableConcept` is read directly; `medicationReference` is resolved within the bundle (including contained Medication resources), so referenced medications are first-class instead of silently missing.
+
+```python
+from healthchain.fhir import get_medications
+
+for med in get_medications(bundle, status="active"):
+    print(med.code, med.display)  # e.g. 313782 Acetaminophen 325 MG Oral Tablet
+
+# Serialize for an agent tool or API response
+payload = [med.model_dump() for med in get_medications(bundle)]
+```
+
+---
+
+## Validation & Loading
+
+Constructing a resource through `fhir.resources` validates *structure* (types, required fields, cardinality) — but it does not check required terminology bindings, and it reports problems by raising Pydantic exceptions. These helpers give you validation as **data you can act on**: a report for agent loops and UIs, or a single rich exception for loaders.
+
+!!! warning "What is and isn't checked"
+    **Checked**: structure (via the Pydantic models) and required bindings on primitive `code` fields (e.g. `MedicationStatement.status`).
+
+    **Not checked**: ValueSet bindings on CodeableConcept/Coding fields, FHIRPath invariants, profile conformance (US Core, UK Core), and reference integrity. For full conformance validation, use a FHIR server's `$validate` operation against the relevant profiles.
+
+### validate_resource()
+
+Validates a resource (dict or instance) and returns a `ValidationReport` — it never raises, so it can sit directly in an agent's build-validate-correct loop.
+
+```python
+from healthchain.fhir import validate_resource
+
+report = validate_resource({
+    "resourceType": "MedicationStatement",
+    "status": "recorded",  # R5 vocabulary — invalid in R4B!
+    "subject": {"reference": "Patient/123"},
+    "medicationCodeableConcept": {"text": "Aspirin"},
+})
+
+print(report.valid)  # False
+for issue in report.issues:
+    print(issue.severity, issue.expression, issue.diagnostics)
+# error MedicationStatement.status Value 'recorded' is not in the required value set. ...
+```
+
+The report mirrors FHIR's own `$validate` output shape (severity / code / diagnostics / expression per issue), serializes with `model_dump()`, and converts to a real [OperationOutcome](https://www.hl7.org/fhir/operationoutcome.html) with `report.to_operation_outcome()`. Validation is version-aware — pass `version="R5"` to validate against R5 instead of the session default.
+
+### load_bundle()
+
+Loads a Bundle from a file path, JSON string, or dict — **loudly**. Every entry is validated independently and all problems are aggregated into one `FHIRValidationError`, with expressions locating the offending entry.
+
+```python
+from healthchain.fhir import FHIRValidationError, load_bundle
+
+try:
+    bundle = load_bundle("synthea_patient.json")
+except FHIRValidationError as e:
+    for issue in e.report.issues:
+        print(issue.expression, issue.diagnostics)
+    # Bundle.entry[2].resource.subject  Field required
+```
+
+Compare with `create_resource_from_dict()`, which returns `None` on failure by default — pass `raise_on_error=True` to get the same `FHIRValidationError` + report behavior for single resources.
+
+---
+
 ## Common Patterns
 
 ### Working with Multiple Resource Types
@@ -784,14 +980,12 @@ allergies = get_resources(bundle, "AllergyIntolerance")
                     "resourceType": "MedicationStatement",
                     "id": "hc-86a26eba-63f9-4017-b7b2-5b36f9bad5f1",
                     "status": "unknown",
-                    "medication": {
-                        "concept": {
-                            "coding": [{
-                                "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
-                                "code": "1049221",
-                                "display": "Acetaminophen 325 MG"
-                            }]
-                        }
+                    "medicationCodeableConcept": {
+                        "coding": [{
+                            "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+                            "code": "1049221",
+                            "display": "Acetaminophen 325 MG"
+                        }]
                     },
                     "subject": {"reference": "Patient/123"}
                 }

--- a/docs/reference/utilities/terminology.md
+++ b/docs/reference/utilities/terminology.md
@@ -1,0 +1,89 @@
+# Terminology
+
+Free text is where clinical data starts — "aspirin", "type 2 diabetes", "blood pressure" — but FHIR resources need codings. `healthchain.terminology` is the seam for mapping text to codes: a small protocol any terminology service can implement, and an in-process lookup that works offline with zero setup.
+
+!!! warning "The demo catalog is not a terminology service"
+    `LocalCodeLookup`'s bundled catalog covers a few dozen common concepts so demos, tests, and generated projects run without network access or licenses. For real coverage, put a proper terminology service behind the same `TerminologyLookup` protocol.
+
+## Quick Start
+
+```python
+from healthchain.terminology import LocalCodeLookup
+
+lookup = LocalCodeLookup()
+
+# Every query word must match — strengths and brands narrow results
+results = lookup.search("metoprolol 25")
+print(results[0].code, results[0].display)
+# 866427 24 HR metoprolol succinate 25 MG Extended Release Oral Tablet
+
+# Restrict to one code system
+from healthchain.terminology import ICD10CM
+condition = lookup.search("hypertension", system=ICD10CM)[0]
+print(condition.code)  # I10
+```
+
+Results are `Coding` models (`code` / `display` / `system`), ranked tightest-match-first, and serialize with `model_dump()` — so a lookup can be returned directly from an agent tool. The point of handing a model a lookup tool is that it uses a **returned code instead of inventing one**.
+
+## The catalog
+
+The bundled demo catalog ships license-free code systems only:
+
+| System | Constant | Contents |
+|--------|----------|----------|
+| RxNorm | `RXNORM` | Common medications with strengths |
+| LOINC | `LOINC` | Common labs and vital signs |
+| ICD-10-CM | `ICD10CM` | Common conditions |
+
+(No SNOMED CT — its license doesn't permit redistribution in an open-source package.)
+
+Replace it with your own formulary or code list:
+
+```python
+from healthchain.terminology import Coding, LocalCodeLookup, RXNORM
+
+site_lookup = LocalCodeLookup(catalog=[
+    Coding(code="197361", display="amLODIPine 5 MG Oral Tablet", system=RXNORM),
+    {"code": "314076", "display": "lisinopril 10 MG Oral Tablet", "system": RXNORM},
+])
+```
+
+## The protocol
+
+Anything with a `search(text, system) -> list[Coding]` method is a `TerminologyLookup` — the protocol is [runtime-checkable](https://docs.python.org/3/library/typing.html#typing.runtime_checkable), and structural, so implementations don't need to inherit anything:
+
+```python
+from healthchain.terminology import Coding, TerminologyLookup
+
+class MyTerminologyService:
+    """e.g. backed by a FHIR $lookup endpoint or a hosted MCP server."""
+
+    def search(self, text: str, system: str | None = None) -> list[Coding]:
+        ...
+
+assert isinstance(MyTerminologyService(), TerminologyLookup)
+```
+
+Write code against the protocol, and swap `LocalCodeLookup` for a real service when you deploy.
+
+## Putting it together
+
+Look up a code, build the resource, validate it — the write loop an agent (or you) runs:
+
+```python
+from healthchain.fhir import create_medication_statement, validate_resource
+from healthchain.terminology import LocalCodeLookup, RXNORM
+
+lookup = LocalCodeLookup()
+
+coding = lookup.search("acetaminophen 325", system=RXNORM)[0]
+medication = create_medication_statement(
+    subject="Patient/123",
+    status="active",
+    code=coding.code,
+    display=coding.display,
+    system=coding.system,
+)
+report = validate_resource(medication)
+assert report.valid
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,7 @@ nav:
         - In Development: reference/interop/experimental.md
       - Utilities:
         - FHIR Helpers: reference/utilities/fhir_helpers.md
+        - Terminology: reference/utilities/terminology.md
         - Sandbox: reference/utilities/sandbox.md
         - Data Generator: reference/utilities/data_generator.md
   - API Reference:
@@ -91,6 +92,7 @@ nav:
       - api/sandbox.md
       - api/interop.md
       - api/fhir_helpers.md
+      - api/terminology.md
   - Community:
       - community/index.md
 


### PR DESCRIPTION
Documentation pass for the agent-toolkit work (#240–#245).

- `fhir_helpers.md`: new **Validation & Loading** and **Reading Coded Entries** sections; `resolve_reference()` under Bundle Operations; `create_dosage()` and the `dosage`/`onset` kwargs; the "what is and isn't checked" warning on validation
- fixes three pre-existing R5-shaped medication examples (`medication.concept` → `medicationCodeableConcept`)
- new Terminology reference page + mkdocstrings API page and nav entries

All code examples were verified by execution against `main`.

Advances #239.

🤖 Generated with [Claude Code](https://claude.com/claude-code)