### PR TITLE
Add declarative governance config section

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -22,6 +22,16 @@ security:
 compliance:
   audit_log: ./logs/audit.jsonl
 
+# Governance context is optional and purely declarative
+# governance:
+#   standards:
+#     - dcb0129
+#     - dcb0160
+#   clinical_safety_officer: ""
+#   data_access_agreement: ""
+#   dpia_required: false
+#   notes: ""
+
 site:
   name: ""
   environment: development
@@ -72,6 +82,39 @@ site:
 
 !!! note "Audit logging"
     When `audit_log` is set, every request is appended as a JSONL entry containing `timestamp`, `method`, `path`, `status_code`, `duration_ms`, `request_id`, and `user`. The log directory is created automatically if missing. When `api-key` auth is also enabled, `user` records the authenticated identity.
+
+---
+
+## `governance`
+
+Optional deployment governance metadata. This section records context only:
+HealthChain does not validate compliance claims, enforce policy, or expose these
+values through `/health` or other HTTP endpoints.
+
+```yaml
+governance:
+  standards:
+    - dcb0129
+    - dcb0160
+    - organisation-policy-v1
+  clinical_safety_officer: Dr Jane Smith
+  data_access_agreement: ./governance/daa.pdf
+  dpia_required: true
+  notes: Reviewed by the deployment board.
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `standards` | list of strings | `[]` | Applicable governance or compliance identifiers. Values are deliberately open and are not validated against a fixed set. |
+| `clinical_safety_officer` | string | `""` | Name or reference for the deployment's clinical safety officer |
+| `data_access_agreement` | path or URL | `""` | Location of the signed data access agreement |
+| `dpia_required` | bool | `false` | Whether a data protection impact assessment is required |
+| `notes` | string | `""` | Free-form deployment governance notes |
+
+When configured, `healthchain serve` shows the standards and clinical safety
+officer in its startup banner. `healthchain status` also reports whether a data
+access agreement is configured and whether a DPIA is required; it does not print
+the agreement path or URL.
 
 ---
 

--- a/healthchain/cli.py
+++ b/healthchain/cli.py
@@ -278,6 +278,16 @@ security:
 compliance:
   audit_log: ./logs/audit.jsonl
 
+# Governance context — declarative metadata only; no compliance enforcement
+# governance:
+#   standards:             # open identifiers, e.g. dcb0129, dcb0160, hipaa
+#     - dcb0129
+#     - dcb0160
+#   clinical_safety_officer: ""
+#   data_access_agreement: ""  # path or URL to the signed agreement
+#   dpia_required: false
+#   notes: ""
+
 # Site / deployment metadata
 site:
   name: ""
@@ -615,6 +625,34 @@ def status():
         print(f"{_key('audit log   ')}{_BOLD}{config.compliance.audit_log}{_RST}")
     else:
         print(f"{_key('audit log   ')}{_DIM}disabled{_RST}")
+
+    governance = config.governance
+    if (
+        governance.standards
+        or governance.clinical_safety_officer
+        or governance.data_access_agreement
+        or governance.dpia_required
+    ):
+        print(_section("Governance"))
+        if governance.standards:
+            print(f"{_key('standards   ')}{', '.join(governance.standards)}")
+        if governance.clinical_safety_officer:
+            print(
+                f"{_key('CSO         ')}"
+                f"{_BOLD}{governance.clinical_safety_officer}{_RST}"
+            )
+        daa_val = (
+            _val_on("configured")
+            if governance.data_access_agreement
+            else f"{_DIM}not configured{_RST}"
+        )
+        print(f"{_key('data access ')}{daa_val}")
+        dpia_val = (
+            f"{_AMBER}required{_RST}"
+            if governance.dpia_required
+            else f"{_DIM}not required{_RST}"
+        )
+        print(f"{_key('DPIA        ')}{dpia_val}")
 
     if config.sources:
         print(_section("Sources"))

--- a/healthchain/cli.py
+++ b/healthchain/cli.py
@@ -632,6 +632,7 @@ def status():
         or governance.clinical_safety_officer
         or governance.data_access_agreement
         or governance.dpia_required
+        or governance.notes
     ):
         print(_section("Governance"))
         if governance.standards:
@@ -653,6 +654,8 @@ def status():
             else f"{_DIM}not required{_RST}"
         )
         print(f"{_key('DPIA        ')}{dpia_val}")
+        if governance.notes:
+            print(f"{_key('notes       ')}{_val_on('configured')}")
 
     if config.sources:
         print(_section("Sources"))

--- a/healthchain/config/appconfig.py
+++ b/healthchain/config/appconfig.py
@@ -75,6 +75,16 @@ class ComplianceConfig(BaseModel):
     audit_log: Optional[str] = None
 
 
+class GovernanceConfig(BaseModel):
+    """Declarative governance context for a deployment."""
+
+    standards: List[str] = []
+    clinical_safety_officer: str = ""
+    data_access_agreement: str = ""
+    dpia_required: bool = False
+    notes: str = ""
+
+
 class SiteConfig(BaseModel):
     name: str = ""
     environment: str = "development"
@@ -96,6 +106,7 @@ class AppConfig(BaseModel):
     service: ServiceConfig = ServiceConfig()
     security: SecurityConfig = SecurityConfig()
     compliance: ComplianceConfig = ComplianceConfig()
+    governance: GovernanceConfig = GovernanceConfig()
     site: SiteConfig = SiteConfig()
     sources: Dict[str, SourceConfig] = {}
     llm: Optional[LLMConfig] = None

--- a/healthchain/gateway/api/app.py
+++ b/healthchain/gateway/api/app.py
@@ -128,6 +128,9 @@ def _print_startup_banner(
     auth = config.security.auth if config else "none"
     tls = config.security.tls.enabled if config else False
     audit_log = config.compliance.audit_log if config else None
+    governance = config.governance if config else None
+    standards = ", ".join(governance.standards) if governance else ""
+    clinical_safety_officer = governance.clinical_safety_officer if governance else ""
     # Check registered gateways first, then fall back to env var presence
     fhir_configured = any(
         hasattr(gw, "connection_manager")
@@ -145,6 +148,10 @@ def _print_startup_banner(
     ]
     if site:
         status.append(_status_row("site:       ", site))
+    if standards:
+        status.append(_status_row("standards:  ", standards))
+    if clinical_safety_officer:
+        status.append(_status_row("CSO:        ", clinical_safety_officer))
     status += [
         "",
         _status_row("auth:       ", _val_auth(auth)),

--- a/tests/config_manager/test_appconfig.py
+++ b/tests/config_manager/test_appconfig.py
@@ -43,7 +43,42 @@ def test_appconfig_missing_fields_use_defaults(tmp_path):
     assert config.security.auth == "none"
     assert config.security.tls.enabled is False
     assert config.compliance.audit_log is None
+    assert config.governance.standards == []
+    assert config.governance.clinical_safety_officer == ""
+    assert config.governance.data_access_agreement == ""
+    assert config.governance.dpia_required is False
+    assert config.governance.notes == ""
     assert config.site.environment == "development"
+
+
+def test_appconfig_governance_parsed_as_declarative_metadata(tmp_path):
+    """AppConfig accepts configured governance context without policy validation."""
+    config_file = tmp_path / "healthchain.yaml"
+    config_file.write_text(
+        """
+governance:
+  standards:
+    - dcb0129
+    - dcb0160
+    - organisation-policy-v1
+  clinical_safety_officer: Dr Jane Smith
+  data_access_agreement: ./governance/daa.pdf
+  dpia_required: true
+  notes: Reviewed by the deployment board.
+"""
+    )
+
+    config = AppConfig.from_yaml(config_file)
+
+    assert config.governance.standards == [
+        "dcb0129",
+        "dcb0160",
+        "organisation-policy-v1",
+    ]
+    assert config.governance.clinical_safety_officer == "Dr Jane Smith"
+    assert config.governance.data_access_agreement == "./governance/daa.pdf"
+    assert config.governance.dpia_required is True
+    assert config.governance.notes == "Reviewed by the deployment board."
 
 
 def test_appconfig_invalid_auth_raises(tmp_path):

--- a/tests/gateway/test_api_app.py
+++ b/tests/gateway/test_api_app.py
@@ -6,7 +6,8 @@ from fastapi import Depends, HTTPException
 from fastapi.testclient import TestClient
 from fastapi.exceptions import RequestValidationError
 
-from healthchain.gateway.api.app import HealthChainAPI
+from healthchain.config.appconfig import AppConfig, GovernanceConfig
+from healthchain.gateway.api.app import HealthChainAPI, _print_startup_banner
 from healthchain.gateway.api.dependencies import (
     get_event_dispatcher,
     get_gateway,
@@ -82,6 +83,51 @@ def test_app_creation(mock_dispatcher):
     app = HealthChainAPI(enable_events=True, event_dispatcher=mock_dispatcher)
     assert app.get_event_dispatcher() is mock_dispatcher
     assert app.enable_events is True
+
+
+def test_startup_banner_displays_configured_governance(capsys):
+    """Startup banner shows standards and CSO when they are configured."""
+    config = AppConfig(
+        governance=GovernanceConfig(
+            standards=["dcb0129", "dcb0160"],
+            clinical_safety_officer="Dr Jane Smith",
+            data_access_agreement="./governance/daa.pdf",
+            dpia_required=True,
+        )
+    )
+
+    _print_startup_banner(
+        title=config.name,
+        version=config.version,
+        gateways={},
+        services={},
+        docs_url="/docs",
+        config=config,
+    )
+
+    output = capsys.readouterr().out
+    assert "dcb0129, dcb0160" in output
+    assert "Dr Jane Smith" in output
+    assert "./governance/daa.pdf" not in output
+    assert "DPIA" not in output
+
+
+def test_startup_banner_is_silent_for_default_governance(capsys):
+    """Startup banner omits governance rows when no context is configured."""
+    config = AppConfig()
+
+    _print_startup_banner(
+        title=config.name,
+        version=config.version,
+        gateways={},
+        services={},
+        docs_url="/docs",
+        config=config,
+    )
+
+    output = capsys.readouterr().out
+    assert "standards:" not in output
+    assert "CSO:" not in output
 
 
 def test_lifespan_startup_shutdown():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -191,6 +191,22 @@ def test_new_project_yaml_contains_project_name(tmp_path):
     assert "named-app" in yaml_content
 
 
+def test_new_project_yaml_contains_commented_governance_section(tmp_path):
+    """Generated config documents governance fields without enabling the block."""
+    project_dir = tmp_path / "governed-app"
+
+    with patch("builtins.print"):
+        new_project(str(project_dir), "default")
+
+    yaml_content = (project_dir / "healthchain.yaml").read_text()
+    assert "# governance:" in yaml_content
+    assert "#   standards:" in yaml_content
+    assert '#   clinical_safety_officer: ""' in yaml_content
+    assert '#   data_access_agreement: ""' in yaml_content
+    assert "#   dpia_required: false" in yaml_content
+    assert "\ngovernance:" not in yaml_content
+
+
 def test_new_project_rejects_existing_directory(tmp_path):
     """new_project prints an error and does not overwrite an existing directory."""
     project_dir = tmp_path / "existing-app"
@@ -227,6 +243,12 @@ def test_status_displays_config_fields(mock_load):
     mock_config.security.tls.enabled = False
     mock_config.security.allowed_origins = ["*"]
     mock_config.compliance.audit_log = "./logs/audit.jsonl"
+    mock_config.governance.standards = []
+    mock_config.governance.clinical_safety_officer = ""
+    mock_config.governance.data_access_agreement = ""
+    mock_config.governance.dpia_required = False
+    mock_config.sources = {}
+    mock_config.llm = None
     mock_load.return_value = mock_config
 
     with patch("builtins.print") as mock_print:
@@ -238,6 +260,41 @@ def test_status_displays_config_fields(mock_load):
     assert "production" in print_output
     assert "Test Hospital" in print_output
     assert "audit.jsonl" in print_output
+    assert "Governance" not in print_output
+
+
+@patch("healthchain.config.appconfig.AppConfig.load")
+def test_status_displays_configured_governance_fields(mock_load):
+    """status shows configured governance context without exposing agreement details."""
+    mock_config = MagicMock()
+    mock_config.name = "test-app"
+    mock_config.version = "1.0.0"
+    mock_config.service.type = "fhir-gateway"
+    mock_config.service.port = 8000
+    mock_config.site.environment = "production"
+    mock_config.site.name = ""
+    mock_config.security.auth = "none"
+    mock_config.security.tls.enabled = False
+    mock_config.security.allowed_origins = ["*"]
+    mock_config.compliance.audit_log = None
+    mock_config.governance.standards = ["dcb0129", "dcb0160"]
+    mock_config.governance.clinical_safety_officer = "Dr Jane Smith"
+    mock_config.governance.data_access_agreement = "./governance/daa.pdf"
+    mock_config.governance.dpia_required = True
+    mock_config.sources = {}
+    mock_config.llm = None
+    mock_load.return_value = mock_config
+
+    with patch("builtins.print") as mock_print:
+        status()
+
+    print_output = " ".join(str(call) for call in mock_print.call_args_list)
+    assert "Governance" in print_output
+    assert "dcb0129, dcb0160" in print_output
+    assert "Dr Jane Smith" in print_output
+    assert "configured" in print_output
+    assert "required" in print_output
+    assert "./governance/daa.pdf" not in print_output
 
 
 @pytest.mark.parametrize(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -247,6 +247,7 @@ def test_status_displays_config_fields(mock_load):
     mock_config.governance.clinical_safety_officer = ""
     mock_config.governance.data_access_agreement = ""
     mock_config.governance.dpia_required = False
+    mock_config.governance.notes = ""
     mock_config.sources = {}
     mock_config.llm = None
     mock_load.return_value = mock_config
@@ -281,6 +282,7 @@ def test_status_displays_configured_governance_fields(mock_load):
     mock_config.governance.clinical_safety_officer = "Dr Jane Smith"
     mock_config.governance.data_access_agreement = "./governance/daa.pdf"
     mock_config.governance.dpia_required = True
+    mock_config.governance.notes = "Reviewed by the deployment board."
     mock_config.sources = {}
     mock_config.llm = None
     mock_load.return_value = mock_config
@@ -295,6 +297,41 @@ def test_status_displays_configured_governance_fields(mock_load):
     assert "configured" in print_output
     assert "required" in print_output
     assert "./governance/daa.pdf" not in print_output
+    assert "notes" in print_output
+    assert "Reviewed by the deployment board." not in print_output
+
+
+@patch("healthchain.config.appconfig.AppConfig.load")
+def test_status_displays_notes_only_governance_as_configured(mock_load):
+    """status makes notes-only governance visible without printing free-form text."""
+    mock_config = MagicMock()
+    mock_config.name = "test-app"
+    mock_config.version = "1.0.0"
+    mock_config.service.type = "fhir-gateway"
+    mock_config.service.port = 8000
+    mock_config.site.environment = "production"
+    mock_config.site.name = ""
+    mock_config.security.auth = "none"
+    mock_config.security.tls.enabled = False
+    mock_config.security.allowed_origins = ["*"]
+    mock_config.compliance.audit_log = None
+    mock_config.governance.standards = []
+    mock_config.governance.clinical_safety_officer = ""
+    mock_config.governance.data_access_agreement = ""
+    mock_config.governance.dpia_required = False
+    mock_config.governance.notes = "Internal governance context"
+    mock_config.sources = {}
+    mock_config.llm = None
+    mock_load.return_value = mock_config
+
+    with patch("builtins.print") as mock_print:
+        status()
+
+    print_output = " ".join(str(call) for call in mock_print.call_args_list)
+    assert "Governance" in print_output
+    assert "notes" in print_output
+    assert "configured" in print_output
+    assert "Internal governance context" not in print_output
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What and why

Adds the first governance-as-config iteration agreed in #207. Governance remains deployment metadata only: it records context without enforcing policy, validating compliance claims, or exposing governance data over HTTP.

The implementation:

- keeps `GovernanceConfig` beside the other top-level `healthchain.yaml` models and gives `AppConfig` a default instance for backwards compatibility
- uses an open `standards: list[str]` because DCB0129 and DCB0160 can both apply, while deployments may also need ISO, regulatory, or organisation-specific identifiers
- surfaces standards and the clinical safety officer conditionally in the startup banner
- adds a conditional Governance section to `healthchain status`, reporting only whether a data access agreement is configured rather than printing its path or URL
- adds the entire governance block as commented guidance in generated projects
- documents the declarative boundary and adds parsing, scaffold, banner, and status coverage

`data_access_agreement`, `dpia_required`, and `notes` remain informational; there is no enforcement or domain validation in this PR.

Closes #207

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ Feature
- [x] 📚 Docs / cookbook
- [x] 🧪 Tests

## Testing

- `ruff check .` — passes
- Affected config, CLI, and gateway tests — 54 passed
- Full suite on Windows — 766 passed, 16 skipped, 3 existing sandbox failures because timestamp filenames contain `:`, which is invalid on Windows; no governance tests failed

## Checklist

- [ ] Linked to an open `help wanted` issue and commented before starting — #207 is a design issue; implementation was explicitly approved by the maintainer in the issue discussion
- [ ] `uv run pytest` passes locally — see the Windows-only filename failures above; Linux CI is expected to cover the supported path
- [x] I can explain every decision in this PR if asked